### PR TITLE
Adding new checkbox on summit form

### DIFF
--- a/src/components/forms/summit-form.js
+++ b/src/components/forms/summit-form.js
@@ -649,6 +649,16 @@ class SummitForm extends React.Component {
                                 </label>
                             </div>
                         </div>
+                        <div className="col-md-6 checkboxes-div">
+                            <div className="form-check abc-checkbox">
+                                <input type="checkbox" id="registration_send_order_email_automatically"
+                                       checked={entity.registration_send_order_email_automatically} onChange={this.handleChange}
+                                       className="form-check-input"/>
+                                <label className="form-check-label" htmlFor="registration_send_order_email_automatically">
+                                    {T.translate("edit_summit.registration_send_order_email_automatically")}
+                                </label>
+                            </div>
+                        </div>
                     </div>
                 </Panel>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -290,6 +290,7 @@
     "registration_send_ticket_as_pdf_attachment_on_ticket_email" : "Send Ticket as Attachment (PDF) on ticket Email",
     "registration_send_ticket_email_automatically" : "Send Ticket Email Automatically?",
     "registration_allow_automatic_reminder_emails" : "Allow Automatic Reminder Emails (Incomplete Order/Tickets)?",
+    "registration_send_order_email_automatically": "Send Order Confirmation Email Automatically?",
     "allow_update_attendee_extra_questions": "Allow Attendee to update extra questions?",
     "placeholders": {
       "api_feed_type": "Select API feed type...",

--- a/src/reducers/summits/current-summit-reducer.js
+++ b/src/reducers/summits/current-summit-reducer.js
@@ -109,6 +109,7 @@ export const DEFAULT_ENTITY = {
     registration_send_qr_as_image_attachment_on_ticket_email : false,
     registration_send_ticket_as_pdf_attachment_on_ticket_email : false,
     registration_allow_automatic_reminder_emails : true,
+    registration_send_order_email_automatically: true,
 };
 
 const DEFAULT_STATE = {


### PR DESCRIPTION
* Adds new checkbox on summit form to enable/disable the "Send Order Confirmation Email Automatically?" prop
* Adds new prop to reducer

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/19543853/160663176-76e22c3d-d4ff-449a-96c7-1dc1b1f67f8e.png">

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2875113

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>