### PR TITLE
Adding registration company to menu

### DIFF
--- a/src/components/nav-menu/index.js
+++ b/src/components/nav-menu/index.js
@@ -191,6 +191,7 @@ class NavMenu extends React.Component {
                     {name:'tax_type_list', linkUrl:`summits/${summit_id}/tax-types`},
                     {name:'refund_policy_list', linkUrl:`summits/${summit_id}/refund-policies`},
                     {name:'payment_profiles_list', linkUrl:`summits/${summit_id}/payment-profiles`},
+                    {name:'registration_companies_list', linkUrl:`summits/${summit_id}/registration-companies`},
                 ]
             },
             {name: 'badges', iconClass: 'fa-id-card-o', accessRoute: 'badges',

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -126,6 +126,7 @@
     "email_flow_events": "Email Activities",
     "admin_access": "Admin Access Groups",
     "registration_invitation_list": "Registration Invitations",
+    "registration_companies_list": "Registration Companies",
     "media_file_types": "Media File Types",
     "media_uploads": "Media Upload Types",
     "track_chairs": "Track Chairs",


### PR DESCRIPTION
* Adds the registration companies page (#60) to the menu

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=2896775&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>