### PR TITLE
Add dropdown with selection plan for summit documents

### DIFF
--- a/src/actions/summitdoc-actions.js
+++ b/src/actions/summitdoc-actions.js
@@ -111,10 +111,6 @@ export const saveSummitDoc = (entity, file) => (dispatch, getState) => {
     const normalizedEntity = normalizeEntity(entity);
     const params = { access_token : accessToken };
 
-    console.log('entiy', entity)
-    console.log('normlaized', normalizedEntity);
-
-
     if (entity.id) {
 
         putFile(

--- a/src/actions/summitdoc-actions.js
+++ b/src/actions/summitdoc-actions.js
@@ -111,6 +111,9 @@ export const saveSummitDoc = (entity, file) => (dispatch, getState) => {
     const normalizedEntity = normalizeEntity(entity);
     const params = { access_token : accessToken };
 
+    console.log('entiy', entity)
+    console.log('normlaized', normalizedEntity);
+
 
     if (entity.id) {
 
@@ -190,6 +193,10 @@ const normalizeEntity = (entity) => {
 
     if (!entity.show_always && entity.event_types) {
         normalizedEntity['event_types[]'] = entity.event_types;
+    }
+
+    if(!entity.selection_plan_id) {
+        normalizedEntity['selection_plan_id'] = 0;
     }
 
     return normalizedEntity;

--- a/src/components/forms/summitdoc-form.js
+++ b/src/components/forms/summitdoc-form.js
@@ -113,6 +113,9 @@ class SummitDocForm extends React.Component {
             .filter( t => t.should_be_available_on_cfp )
             .map(et => ({value: et.id, label: et.name}));
 
+        let selection_plans_ddl = currentSummit.selection_plans
+            .map(et => ({value: et.id, label: et.name}));
+
         return (
             <form className="summitdoc-form">
                 <input type="hidden" id="id" value={entity.id} />
@@ -161,13 +164,26 @@ class SummitDocForm extends React.Component {
                             error={this.hasErrors('description')}
                         />
                     </div>
-                    <div className="col-md-4 checkboxes-div">
+                    <div className="col-md-4">
+                        <label> {T.translate("summitdoc.selection_plan")}</label>
+                        <Dropdown
+                            id="selection_plan"
+                            value={entity.selection_plan_id}
+                            isClearable={true}
+                            placeholder={T.translate("summitdoc.placeholders.selection_plan")}
+                            options={selection_plans_ddl}
+                            onChange={this.handleChange}
+                        />
+                    </div>
+                </div>
+                <div className='row form-group'>
+                    <div className="col-md-4 col-md-offset-8 checkboxes-div">
                         <div className="form-check abc-checkbox">
-                            <input type="checkbox" id="show_always" checked={entity.show_always}
-                                   onChange={this.handleChange} className="form-check-input"/>
-                            <label className="form-check-label" htmlFor="show_always">
-                                {T.translate("summitdoc.show_always")}
-                            </label>
+                                <input type="checkbox" id="show_always" checked={entity.show_always}
+                                    onChange={this.handleChange} className="form-check-input"/>
+                                <label className="form-check-label" htmlFor="show_always">
+                                    {T.translate("summitdoc.show_always")}
+                                </label>
                         </div>
                     </div>
                 </div>

--- a/src/components/forms/summitdoc-form.js
+++ b/src/components/forms/summitdoc-form.js
@@ -167,7 +167,7 @@ class SummitDocForm extends React.Component {
                     <div className="col-md-4">
                         <label> {T.translate("summitdoc.selection_plan")}</label>
                         <Dropdown
-                            id="selection_plan"
+                            id="selection_plan_id"
                             value={entity.selection_plan_id}
                             isClearable={true}
                             placeholder={T.translate("summitdoc.placeholders.selection_plan")}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1634,9 +1634,11 @@
     "delete_warning": "Are you sure you want to delete doc ",
     "saved": "Doc saved successfully.",
     "created": "Doc created successfully.",
+    "selection_plan": "Selection Plan",
     "placeholders": {
       "search": "Search docs by name",
-      "select_type": "Select Activity Type"
+      "select_type": "Select Activity Type",
+      "selection_plan": "Select a Selection Plan ..."
     }
   },
   "email_flow_event_list": {

--- a/src/reducers/summitdoc/summitdoc-reducer.js
+++ b/src/reducers/summitdoc/summitdoc-reducer.js
@@ -23,13 +23,14 @@ import { LOGOUT_USER, VALIDATE } from 'openstack-uicore-foundation/lib/actions';
 import { SET_CURRENT_SUMMIT } from '../../actions/summit-actions';
 
 export const DEFAULT_ENTITY = {
-    id           : 0,
-    name         : '',
-    label        : '',
-    description  : '',
-    event_types  : [],
-    file_preview : '',
-    show_always : false,
+    id                  : 0,
+    name                : '',
+    label               : '',
+    description         : '',
+    event_types         : [],
+    file_preview        : '',
+    selection_plan_id   : null,
+    show_always         : false,
 }
 
 const DEFAULT_STATE = {


### PR DESCRIPTION
* Add selection plan on summit documents form

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/19543853/165831978-317b39d8-dcdf-4c92-b458-14e0b530ce2d.png">

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=2907376

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>