### PR TITLE
Change copy text on submission lock down info icon

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -324,7 +324,7 @@
     "submission_begin_date": "Submissions Start",
     "submission_end_date": "Submissions End",
     "submission_lock_down_presentation_status_date": "Submissions Status Lock Down Date",
-    "submission_lock_down_presentation_status_date_info": "Date till presentation status will be show as in review at CFP",
+    "submission_lock_down_presentation_status_date_info": "This date, if set, will cause the submissions to remain 'In Review' until the date passes. This is useful if there are multiple submission rounds or if you need more time to review the track chair selections before updating the status to the submitter and speaker(s).",
     "voting_begin_date": "Voting Start",
     "voting_end_date": "Voting End",
     "selection_begin_date": "TC Selections Start",


### PR DESCRIPTION
* Change text on info icon

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/19543853/211915349-02aa81f0-24f2-43e4-8c7f-f059f896aa5c.png">


ref: https://tipit.avaza.com/project/view/188885#!tab=task-pane&task=3173856

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>