### PR TITLE
Add setting to hide company field in reg lite

### DIFF
--- a/src/components/forms/summit-form.js
+++ b/src/components/forms/summit-form.js
@@ -707,6 +707,16 @@ class SummitForm extends React.Component {
                                 </label>
                             </div>
                         </div>
+                        <div className="col-md-4 checkboxes-div">
+                            <div className="form-check abc-checkbox">
+                                <input type="checkbox" id="REG_LITE_SHOW_COMPANY_INPUT"
+                                       checked={regLiteMarketingSettings?.REG_LITE_SHOW_COMPANY_INPUT?.value} onChange={this.handleChange}
+                                       className="form-check-input"/>
+                                <label className="form-check-label" htmlFor="REG_LITE_SHOW_COMPANY_INPUT">
+                                    {T.translate("edit_summit.reg_lite_show_company_input")}
+                                </label>
+                            </div>
+                        </div>
                         <div className="col-md-4">
                             <label>
                                 {T.translate("edit_summit.reg_lite_company_input_placeholder")} &nbsp;

--- a/src/components/forms/summit-form.js
+++ b/src/components/forms/summit-form.js
@@ -699,16 +699,6 @@ class SummitForm extends React.Component {
                     <div className="row form-group">
                         <div className="col-md-4 checkboxes-div">
                             <div className="form-check abc-checkbox">
-                                <input type="checkbox" id="REG_LITE_ALLOW_PROMO_CODES"
-                                       checked={regLiteMarketingSettings?.REG_LITE_ALLOW_PROMO_CODES?.value} onChange={this.handleChange}
-                                       className="form-check-input"/>
-                                <label className="form-check-label" htmlFor="REG_LITE_ALLOW_PROMO_CODES">
-                                    {T.translate("edit_summit.reg_lite_allow_promo_codes")}
-                                </label>
-                            </div>
-                        </div>
-                        <div className="col-md-4 checkboxes-div">
-                            <div className="form-check abc-checkbox">
                                 <input type="checkbox" id="REG_LITE_SHOW_COMPANY_INPUT"
                                        checked={regLiteMarketingSettings?.REG_LITE_SHOW_COMPANY_INPUT?.value} onChange={this.handleChange}
                                        className="form-check-input"/>
@@ -742,6 +732,18 @@ class SummitForm extends React.Component {
                                 value={regLiteMarketingSettings?.REG_LITE_COMPANY_DDL_PLACEHOLDER?.value}
                                 onChange={this.handleChange}
                             />
+                        </div>
+                    </div>
+                    <div className="row form-group">
+                        <div className="col-md-12 checkboxes-div">
+                            <div className="form-check abc-checkbox">
+                                <input type="checkbox" id="REG_LITE_ALLOW_PROMO_CODES"
+                                       checked={regLiteMarketingSettings?.REG_LITE_ALLOW_PROMO_CODES?.value} onChange={this.handleChange}
+                                       className="form-check-input"/>
+                                <label className="form-check-label" htmlFor="REG_LITE_ALLOW_PROMO_CODES">
+                                    {T.translate("edit_summit.reg_lite_allow_promo_codes")}
+                                </label>
+                            </div>
                         </div>
                     </div>
                 </Panel>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -317,6 +317,7 @@
     "reg_lite_company_input_placeholder": "Company Text Input Placeholder",
     "reg_lite_company_input_placeholder_info": "This placeholder will be used for the company text input field on the registration lite.",
     "reg_lite_allow_promo_codes": "Allow Promo Codes on Registration Lite ?",
+    "reg_lite_show_company_input": "Show user company input during registration?",
     "reg_lite_company_ddl_placeholder": "Company Dropdown Placeholder",
     "reg_lite_company_ddl_placeholder_info": "This placeholder will be used for the company dropdown field on the registration lite.",
     "placeholders": {

--- a/src/reducers/summits/current-summit-reducer.js
+++ b/src/reducers/summits/current-summit-reducer.js
@@ -121,9 +121,10 @@ export const DEFAULT_ENTITY = {
 };
 
 const DEFAULT_REG_LITE_MARKETING_SETTINGS = {
-    REG_LITE_ALLOW_PROMO_CODES: {id : 0 , value: true},
-    REG_LITE_COMPANY_INPUT_PLACEHOLDER :{id : 0 , value: 'Enter your company'},
-    REG_LITE_COMPANY_DDL_PLACEHOLDER : {id : 0 , value: 'Select a company'},
+    REG_LITE_ALLOW_PROMO_CODES: {id: 0 , value: true},
+    REG_LITE_SHOW_COMPANY_INPUT: {id: 0 , value: true},
+    REG_LITE_COMPANY_INPUT_PLACEHOLDER: {id: 0 , value: 'Enter your company'},
+    REG_LITE_COMPANY_DDL_PLACEHOLDER: {id: 0 , value: 'Select a company'},
 };
 
 const DEFAULT_STATE = {
@@ -398,7 +399,7 @@ const currentSummitReducer = (state = DEFAULT_STATE, action) => {
 
             data.forEach(setting => {
                 let value = setting.value;
-                if(setting.key === 'REG_LITE_ALLOW_PROMO_CODES'){
+                if(setting.key === 'REG_LITE_ALLOW_PROMO_CODES' || setting.key === 'REG_LITE_SHOW_COMPANY_INPUT'){
                     value = value === '1';
                 }
                 reg_lite_marketing_settings[setting.key] = { id : setting.id, value : value};


### PR DESCRIPTION
Added a setting for the event admin to choose to hide the company field in the registration lite component.

Related:
- https://github.com/OpenEventKit/eventsite/pull/1
- https://github.com/OpenEventKit/summit-registration-lite/pull/2