### PR TITLE
Add new reg-lite settings for no allowed tickets message

### DIFF
--- a/src/actions/marketing-actions.js
+++ b/src/actions/marketing-actions.js
@@ -77,7 +77,7 @@ export const getMarketingSettings = (term = null, page = 1, perPage = 10, order 
     );
 };
 
-export const getMarketingSettingsForRegLite = (page = 1, perPage = 20) => (dispatch, getState) => {
+export const getMarketingSettingsForRegLite = (page = 1, perPage = 100) => (dispatch, getState) => {
     const {currentSummitState} = getState();
     const {currentSummit} = currentSummitState;
 

--- a/src/actions/marketing-actions.js
+++ b/src/actions/marketing-actions.js
@@ -77,7 +77,7 @@ export const getMarketingSettings = (term = null, page = 1, perPage = 10, order 
     );
 };
 
-export const getMarketingSettingsForRegLite = (page = 1, perPage = 10) => (dispatch, getState) => {
+export const getMarketingSettingsForRegLite = (page = 1, perPage = 20) => (dispatch, getState) => {
     const {currentSummitState} = getState();
     const {currentSummit} = currentSummitState;
 

--- a/src/components/forms/summit-form.js
+++ b/src/components/forms/summit-form.js
@@ -878,6 +878,20 @@ class SummitForm extends React.Component {
                     </div>
                     <div className="row form-group">
                         <div className="col-md-12">
+                            <label>
+                                {T.translate("edit_summit.reg_lite_no_allowed_tickets_message")}
+                            </label>&nbsp;
+                            <i className="fa fa-info-circle" aria-hidden="true"
+                               title={T.translate("edit_summit.reg_lite_no_allowed_tickets_message_info")} />
+                            <TextEditor
+                                id="REG_LITE_NO_ALLOWED_TICKETS_MESSAGE"
+                                value={regLiteMarketingSettings?.REG_LITE_NO_ALLOWED_TICKETS_MESSAGE?.value}
+                                onChange={this.handleChange}
+                            />                            
+                        </div>                        
+                    </div>                
+                    <div className="row form-group">
+                        <div className="col-md-12">
                             <label>{T.translate("edit_summit.check_in_settings")}</label><hr/>
                         </div>
                     </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -349,6 +349,8 @@
     "reg_lite_order_complete_step_2nd_paragraph_info": "2nd Paragraph shown on Order Complete Step When is not the first order of the Buyer.",
     "reg_lite_order_complete_btn_label" : "Order Complete Button",
     "reg_lite_order_complete_btn_label_info" : "Order Complete Button Text shown on Order Complete Step When is not the first order of the Buyer.",
+    "reg_lite_no_allowed_tickets_message": "No Allowed Tickets Message",
+    "reg_lite_no_allowed_tickets_message_info": "This message is shown when there are no available tickets to buy",
     "print_app_hide_find_ticket_by_fullname": "Hide Find By FullName Criteria",
     "print_app_hide_find_ticket_by_email": "Hide Find By Email Criteria",
     "reg_lite_settings": "Registration Lite Settings",

--- a/src/reducers/summits/current-summit-reducer.js
+++ b/src/reducers/summits/current-summit-reducer.js
@@ -132,6 +132,7 @@ const DEFAULT_REG_LITE_MARKETING_SETTINGS = {
             ' assign/reassign tickets or to complete any required ticket details.'},
     REG_LITE_ORDER_COMPLETE_STEP_2ND_PARAGRAPH: {id: 0, value: ''},
     REG_LITE_ORDER_COMPLETE_BTN_LABEL: {id: 0, value: ''},
+    REG_LITE_NO_ALLOWED_TICKETS_MESSAGE: {id: 0, value: `<span>You already have purchased all available tickets for this event and/or there are no tickets available for you to purchase.</span><br/><span><a href="/a/my-tickets">Visit the my orders / my tickets page</a> to review your existing tickets.</span>`}
 };
 
 const DEFAULT_PRINT_APP_MARKETING_SETTINGS = {


### PR DESCRIPTION
* New setting for no allowed tickets message on reg-lite widget

<img width="1050" alt="image" src="https://github.com/fntechgit/summit-admin/assets/19543853/4579dbb9-bf13-43ac-8797-3adee5c889a2">

ref: https://tipit.avaza.com/project/view/332800#!tab=task-pane&task=3297179

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>