### PR TITLE
Add description field to promocode table

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -800,6 +800,7 @@
     "add_promocode": "Add Promocode",
     "code": "Code",
     "type": "Type",
+    "description": "Description",
     "owner": "Owner",
     "owner_email": "Owner Email",
     "emailed": "Emailed",

--- a/src/pages/events/summit-event-list-page.js
+++ b/src/pages/events/summit-event-list-page.js
@@ -1000,7 +1000,7 @@ class SummitEventListPage extends React.Component {
 
                 {events.length > 0 &&
                 <div>
-                    <div className='summit-event-list-table-wrapper'>                        
+                    <div className='summit-event-list-table-wrapper'>
                         <Table
                             options={table_options}
                             data={events}

--- a/src/pages/promocodes/promocode-list-page.js
+++ b/src/pages/promocodes/promocode-list-page.js
@@ -131,6 +131,13 @@ class PromocodeListPage extends React.Component {
             { columnKey: 'id', value: T.translate("promocode_list.id"), sortable: true },
             { columnKey: 'code', value: T.translate("promocode_list.code"), sortable: true },
             { columnKey: 'class_name', value: T.translate("promocode_list.type") },
+            { columnKey: 'description', value: T.translate("promocode_list.description"), title: true, render:(row) => {
+                return row.description.length > 50 ? 
+                <td title={row.description}>
+                    {`${row.description.slice(0,50)}...`}
+                </td>
+                 : row.description 
+            }},
             /*{ columnKey: 'owner', value: T.translate("promocode_list.owner") },*/
             { columnKey: 'owner_email', value: T.translate("promocode_list.owner_email") },
             { columnKey: 'email_sent', value: T.translate("promocode_list.emailed") },

--- a/src/pages/promocodes/promocode-list-page.js
+++ b/src/pages/promocodes/promocode-list-page.js
@@ -133,9 +133,9 @@ class PromocodeListPage extends React.Component {
             { columnKey: 'class_name', value: T.translate("promocode_list.type") },
             { columnKey: 'description', value: T.translate("promocode_list.description"), title: true, render:(row) => {
                 return row.description.length > 50 ? 
-                <td title={row.description}>
+                <span title={row.description}>
                     {`${row.description.slice(0,50)}...`}
-                </td>
+                </span>
                  : row.description 
             }},
             /*{ columnKey: 'owner', value: T.translate("promocode_list.owner") },*/

--- a/src/reducers/promocodes/promocode-list-reducer.js
+++ b/src/reducers/promocodes/promocode-list-reducer.js
@@ -106,6 +106,7 @@ const promocodeListReducer = (state = DEFAULT_STATE, action) => {
                 return {
                     id: p.id,
                     class_name: p.class_name,
+                    description: p.description,
                     code: p.code,
                     type: p.type,
                     owner: owner,


### PR DESCRIPTION

<img width="1358" alt="image" src="https://github.com/fntechgit/summit-admin/assets/19543853/4c39fd02-cda2-470e-a35c-0abe1903c508">


ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=3048245&stafilter=NotComplete&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
