### PR TITLE
Update filter name on ticket actions

### DIFF
--- a/src/actions/ticket-actions.js
+++ b/src/actions/ticket-actions.js
@@ -242,8 +242,8 @@ const parseFilters = (filters, term = null) => {
         ))
     }
 
-    if(filters.promocodeTags?.length > 0){
-        filter.push(filters.promocodeTags.reduce(
+    if(filters.promocodeTagsFilter?.length > 0){
+        filter.push(filters.promocodeTagsFilter.reduce(
             (accumulator, t) => accumulator +(accumulator !== '' ? ',':'') +`promo_code_tag==${t.tag}`,
             ''
         ));


### PR DESCRIPTION
* Promo tag filter was renamed on #260 but not on the actions

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3355417

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
