### PR TITLE
Add new info icons for marketing and event site url inputs

### DIFF
--- a/src/components/forms/summit-form.js
+++ b/src/components/forms/summit-form.js
@@ -1027,7 +1027,8 @@ class SummitForm extends React.Component {
                        handleClick={this.toggleSection.bind(this, 'virtual_event')}>
                     <div className="row form-group">
                         <div className="col-md-4">
-                            <label> {T.translate("edit_summit.marketing_site_url")}</label>
+                            <label> {T.translate("edit_summit.marketing_site_url")}</label>&nbsp;
+                            <i className="fa fa-info-circle" aria-hidden="true" title={T.translate("edit_summit.url_registered_idp")} />
                             <Input
                                 className="form-control"
                                 error={this.hasErrors('marketing_site_url')}
@@ -1058,7 +1059,8 @@ class SummitForm extends React.Component {
                     </div>
                     <div className="row form-group">
                         <div className="col-md-6">
-                            <label> {T.translate("edit_summit.virtual_site_url")}</label>
+                            <label> {T.translate("edit_summit.virtual_site_url")}</label>&nbsp;
+                            <i className="fa fa-info-circle" aria-hidden="true" title={T.translate("edit_summit.url_registered_idp")} />
                             <Input
                                 className="form-control"
                                 error={this.hasErrors('virtual_site_url')}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -370,6 +370,7 @@
     "registration_feed_metadata": "Registration Feed Metadata",
     "add_registration_feed_metadata": "Add Feed Metadata",
     "no_reg_feed_metadata": "No registration feed metadata found.",
+    "url_registered_idp": "This url should be registered as allowed redirect uri at related OAUTH2 APP at IDP",
     "placeholders": {
       "api_feed_type": "Select API feed type...",
       "external_registration_feed_type": "Select Ext. Reg. feed type...",


### PR DESCRIPTION
<img width="1043" alt="image" src="https://github.com/fntechgit/summit-admin/assets/19543853/12e3e4ac-5013-45ba-9fb9-30d2ea0d73ca">

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3507209

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
