### PR TITLE
fix: adjust speakers formatting to display on events table

### DIFF
--- a/src/utils/summitUtils.js
+++ b/src/utils/summitUtils.js
@@ -78,7 +78,7 @@ export const formatEventData = (e, summit) => {
       : "N/A",
     speakers:
       Array.isArray(e.speakers) && e.speakers.length > 0
-        ? e.speakers.map((s) => `${s.first_name} ${s.last_name}`).join(",")
+        ? e.speakers.map((s) => `${s.first_name} ${s.last_name}`).join(", ")
         : "N/A",
     speaker_company:
       speakers_companies.length > 0


### PR DESCRIPTION

<img width="1218" alt="image" src="https://github.com/user-attachments/assets/43902748-3ba7-456b-a7af-fd27d86f6a72">

 

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&task=3625301

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
