### PR TITLE
fix: Naming Convention: Change email activities to email events

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2464,7 +2464,7 @@
   },
   "edit_email_flow_event": {
     "email_template_identifier": "Email Template (Associated with Event)",
-    "email_flow_event": "Email Activity",
+    "email_flow_event": "Email Events",
     "flow_name": "eFlow Name",
     "event_type": "Activity Type",
     "saved": "Email template Flow saved successfully.",
@@ -2579,7 +2579,7 @@
     }
   },
   "mail_activity": {
-    "mail_activity": "Email Activity",
+    "mail_activity": "Email Events",
     "template_identifier": "Template",
     "subject": "Subject",
     "sent_date": "Sent Date"


### PR DESCRIPTION
https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskDueDate&view=vertical&task=3438882&stafilter=NotComplete&fileview=grid