### PR TITLE
hotfix: fix the initial type of the purchaseOrders prop on the reducer

### DIFF
--- a/src/reducers/orders/purchase-order-list-reducer.js
+++ b/src/reducers/orders/purchase-order-list-reducer.js
@@ -23,7 +23,7 @@ import {
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
 
 const DEFAULT_STATE = {
-  purchaseOrders: {},
+  purchaseOrders: [],
   term: null,
   order: "created",
   orderDir: 1,


### PR DESCRIPTION
* Fix an issue that occurs when you try to remove a purchase order before the purchase orders have been fetched. (eg. accessing purchase order page from attendee)

<img width="1779" alt="image" src="https://github.com/user-attachments/assets/3c304a8c-c31c-4870-98dc-22ea530dd013" />

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3714969

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
