### PR TITLE
fix: remove condition to hide notes panel when ticket is not assigned

### DIFF
--- a/src/pages/orders/edit-ticket-page.js
+++ b/src/pages/orders/edit-ticket-page.js
@@ -440,7 +440,7 @@ const EditTicketPage = ({
         </Panel>
       )}
 
-      {entity?.id > 0 && entity?.owner?.id > 0 && (
+      {entity?.id > 0 && (
         <Panel
           show={showSection === "admin_notes"}
           title={T.translate("edit_ticket.admin_notes")}


### PR DESCRIPTION
ref: https://tipit.avaza.com/project/view#!tab=task-pane&task=3745459

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
