### PR TITLE
fix: make menu wrapper not interactive when it is closed on mobile

### DIFF
--- a/src/components/menu/menu.module.less
+++ b/src/components/menu/menu.module.less
@@ -25,9 +25,9 @@
 
   &.closed {
     overflow-y: hidden;
-
     .burgerButton {
       display: block;
+      pointer-events: auto;
 
       @media (min-width: 768px) {
         display: none;
@@ -52,6 +52,9 @@
           display: flex;
         }
       }
+    }
+    @media (max-width: 768px) {
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
ref: 
* https://app.clickup.com/t/86b6xh2vg
* https://app.clickup.com/t/86b6xgw81

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
