### PR TITLE
feat: add timezone selector to selection plan edit page

### DIFF
--- a/src/components/forms/selection-plan-form.js
+++ b/src/components/forms/selection-plan-form.js
@@ -145,6 +145,7 @@ class SelectionPlanForm extends React.Component {
     if (!shallowEqual(prevProps.entity, this.props.entity)) {
       state.entity = { ...this.props.entity };
       state.errors = {};
+      state.selectedTimezone = this.props.currentSummit.time_zone_id;
     }
 
     if (!shallowEqual(prevProps.errors, this.props.errors)) {

--- a/src/components/forms/selection-plan-form.js
+++ b/src/components/forms/selection-plan-form.js
@@ -327,7 +327,7 @@ class SelectionPlanForm extends React.Component {
       allowedMembers
     } = this.props;
 
-    const timezoneDdl = timezones.map((tz) => ({ label: tz, value: tz }));
+    const timezoneDdl = (timezones || []).map((tz) => ({ label: tz, value: tz }));
 
     const trackGroupsColumns = [
       { columnKey: "name", value: T.translate("edit_selection_plan.name") },

--- a/src/components/forms/selection-plan-form.js
+++ b/src/components/forms/selection-plan-form.js
@@ -64,7 +64,8 @@ class SelectionPlanForm extends React.Component {
       showSection: "main",
       newMemberEmail: "",
       showImportModal: false,
-      importFile: null
+      importFile: null,
+      selectedTimezone: props.currentSummit.time_zone_id
     };
 
     this.handleTrackGroupLink = this.handleTrackGroupLink.bind(this);
@@ -314,15 +315,19 @@ class SelectionPlanForm extends React.Component {
   }
 
   render() {
-    const { entity, showSection, newMemberEmail, showImportModal } = this.state;
+    const { entity, showSection, newMemberEmail, showImportModal, selectedTimezone } =
+      this.state;
     const {
       currentSummit,
+      timezones,
       extraQuestionsOrderDir,
       extraQuestionsOrder,
       actionTypesOrderDir,
       actionTypesOrder,
       allowedMembers
     } = this.props;
+
+    const timezoneDdl = timezones.map((tz) => ({ label: tz, value: tz }));
 
     const trackGroupsColumns = [
       { columnKey: "name", value: T.translate("edit_selection_plan.name") },
@@ -428,8 +433,6 @@ class SelectionPlanForm extends React.Component {
       }
     };
 
-    console.log("CHECK...", entity, currentSummit);
-
     return (
       <form className="selection-plan-form">
         <input type="hidden" id="id" value={entity.id} />
@@ -509,6 +512,22 @@ class SelectionPlanForm extends React.Component {
         </div>
 
         <div className="row form-group">
+          <div className="col-md-12">
+            <label>
+              {T.translate("edit_selection_plan.time_zone_for_dates")}
+            </label>
+            <Dropdown
+              id="selectedTimezone"
+              value={selectedTimezone}
+              onChange={(ev) =>
+                this.setState({ selectedTimezone: ev.target.value })
+              }
+              options={timezoneDdl}
+            />
+          </div>
+        </div>
+
+        <div className="row form-group">
           <div className="col-md-6">
             <label>
               {" "}
@@ -518,10 +537,10 @@ class SelectionPlanForm extends React.Component {
               id="submission_begin_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.submission_begin_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -534,10 +553,10 @@ class SelectionPlanForm extends React.Component {
               id="submission_end_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.submission_end_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -573,10 +592,10 @@ class SelectionPlanForm extends React.Component {
               id="submission_lock_down_presentation_status_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.submission_lock_down_presentation_status_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -591,10 +610,10 @@ class SelectionPlanForm extends React.Component {
               id="voting_begin_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.voting_begin_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -607,10 +626,10 @@ class SelectionPlanForm extends React.Component {
               id="voting_end_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.voting_end_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -625,10 +644,10 @@ class SelectionPlanForm extends React.Component {
               id="selection_begin_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.selection_begin_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>
@@ -641,10 +660,10 @@ class SelectionPlanForm extends React.Component {
               id="selection_end_date"
               onChange={this.handleChange}
               format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
-              timezone={currentSummit.time_zone_id}
+              timezone={selectedTimezone}
               value={epochToMomentTimeZone(
                 entity.selection_end_date,
-                currentSummit.time_zone_id
+                selectedTimezone
               )}
             />
           </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -446,6 +446,7 @@
     "email": "Email",
     "enabled": "Enabled",
     "hidden": "Hidden",
+    "time_zone_for_dates": "Time Zone for Dates",
     "submission_begin_date": "Submissions Start",
     "submission_end_date": "Submissions End",
     "submission_lock_down_presentation_status_date": "Submissions Status Lock Down Date",

--- a/src/pages/selection-plans/edit-selection-plan-page.js
+++ b/src/pages/selection-plans/edit-selection-plan-page.js
@@ -43,6 +43,7 @@ const EditSelectionPlanPage = ({
   allowedMembers,
   errors,
   history,
+  timezones,
   extraQuestionsOrder,
   extraQuestionsOrderDir,
   updateSelectionPlanExtraQuestionOrder,
@@ -194,6 +195,7 @@ const EditSelectionPlanPage = ({
         entity={entity}
         allowedMembers={allowedMembers}
         currentSummit={currentSummit}
+        timezones={timezones}
         errors={errors}
         extraQuestionsOrder={extraQuestionsOrder}
         extraQuestionsOrderDir={extraQuestionsOrderDir}
@@ -228,9 +230,11 @@ const EditSelectionPlanPage = ({
 
 const mapStateToProps = ({
   currentSummitState,
-  currentSelectionPlanState
+  currentSelectionPlanState,
+  baseState
 }) => ({
   currentSummit: currentSummitState.currentSummit,
+  timezones: baseState.timezones,
   ...currentSelectionPlanState
 });
 


### PR DESCRIPTION
## Summary
- Adds a "Time Zone for Dates" dropdown to the Edit Selection Plan page, positioned between the checkboxes and the date fields
- Defaults to the summit's timezone but allows selecting any timezone for display/input of all 7 date fields (submission start/end, voting start/end, selection start/end, lock down date)
- Client-only change — dates are still sent to the API as UTC epoch timestamps, no backend changes needed

## Test plan
- [ ] Navigate to a selection plan edit page (e.g. `/app/summits/70/selection-plans/67`)
- [ ] Verify the "Time Zone for Dates" dropdown appears below the checkboxes, defaulting to the summit's timezone
- [ ] Change the timezone and verify all date/time pickers update to reflect the new timezone
- [ ] Set a date in a non-summit timezone, save, and confirm the correct time is persisted
- [ ] Reload the page and confirm dates display correctly (dropdown resets to summit timezone)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timezone selector to the selection plan form; chosen timezone is applied to all date/time fields and previews.

* **Localization**
  * Added "Time Zone for Dates" label for the new selector.

* **Bug Fixes**
  * Removed a stray debug log from the form rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="4320" height="3567" alt="EditSelectionPlan" src="https://github.com/user-attachments/assets/a5438c72-5b61-4d22-8a0b-a21db891af36" />
