### PR TITLE
feat: add template popup on sponsor tab

### DIFF
--- a/src/actions/sponsor-pages-actions.js
+++ b/src/actions/sponsor-pages-actions.js
@@ -164,7 +164,7 @@ export const saveSponsorManagedPage =
       `${window.SPONSOR_PAGES_API_URL}/api/v1/summits/${currentSummit.id}/sponsors/${sponsorId}/managed-pages`,
       normalizedEntity,
       snackbarErrorHandler
-    )(params)(dispatch).then(() => {
+    )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
   };

--- a/src/actions/sponsor-pages-actions.js
+++ b/src/actions/sponsor-pages-actions.js
@@ -164,21 +164,31 @@ export const saveSponsorManagedPage =
       `${window.SPONSOR_PAGES_API_URL}/api/v1/summits/${currentSummit.id}/sponsors/${sponsorId}/managed-pages`,
       normalizedEntity,
       snackbarErrorHandler
-    )(params)(dispatch).finally(() => {
-      dispatch(stopLoading());
-    });
+    )(params)(dispatch)
+      .then(() => {
+        dispatch(
+          snackbarSuccessHandler({
+            title: T.translate("general.success"),
+            html: T.translate("edit_sponsor.pages_tab.managed_page_saved")
+          })
+        );
+      })
+      .finally(() => {
+        dispatch(stopLoading());
+      });
   };
 
 const normalizeSponsorManagedPage = (entity) => {
   const normalizedEntity = {
-    show_page_ids: entity.pages,
-    allowed_add_ons: entity.add_ons.map((a) => a.id),
-    apply_to_all_add_ons: false
+    show_page_ids: entity.pages
   };
 
   if (entity.add_ons.includes("all")) {
     normalizedEntity.apply_to_all_add_ons = true;
     normalizedEntity.allowed_add_ons = [];
+  } else {
+    normalizedEntity.allowed_add_ons = entity.add_ons.map((a) => a.id);
+    normalizedEntity.apply_to_all_add_ons = false;
   }
 
   return normalizedEntity;

--- a/src/components/mui/formik-inputs/mui-formik-select-group.js
+++ b/src/components/mui/formik-inputs/mui-formik-select-group.js
@@ -44,6 +44,7 @@ const MuiFormikSelectGroup = ({
   selectAllLabel = "Select All",
   getOptionLabel = (item) => item.name,
   getOptionValue = (item) => item.id,
+  noOptionsLabel = "No items",
   getGroupId = null,
   getGroupLabel = null,
   disabled = false
@@ -213,6 +214,79 @@ const MuiFormikSelectGroup = ({
       .flat()
       .filter(Boolean);
 
+  const renderMenuContent = () => {
+    if (loading) {
+      return (
+        <MenuItem disabled>
+          <CircularProgress size={20} />
+        </MenuItem>
+      );
+    }
+
+    if (options.length === 0) {
+      return (
+        <MenuItem disabled>
+          <ListItemText
+            primary={noOptionsLabel}
+            slotProps={{
+              primary: {
+                sx: {
+                  fontSize: "16px",
+                  color: "#00000061"
+                }
+              }
+            }}
+          />
+        </MenuItem>
+      );
+    }
+
+    return (
+      <>
+        {showSelectAll && (
+          <>
+            <MenuItem
+              value="selectAll"
+              sx={{
+                backgroundColor: "#fafafa",
+                "&:hover": {
+                  backgroundColor: "#f0f0f0"
+                }
+              }}
+              onClick={() => {
+                // custom event value to select all
+                handleChange({ target: { value: ["selectAll"] } });
+              }}
+            >
+              <Checkbox
+                checked={isAllSelected}
+                indeterminate={selectedValues.length > 0 && !isAllSelected}
+                sx={{
+                  p: 1,
+                  "& svg": {
+                    fontSize: 24
+                  }
+                }}
+              />
+              <ListItemText
+                primary={selectAllLabel}
+                slotProps={{
+                  primary: {
+                    sx: {
+                      fontSize: "16px"
+                    }
+                  }
+                }}
+              />
+            </MenuItem>
+            <Divider />
+          </>
+        )}
+        {renderGroupedOptions()}
+      </>
+    );
+  };
+
   const IconWithLoading = useMemo(() => getCustomIcon(loading), [loading]);
 
   return (
@@ -243,54 +317,7 @@ const MuiFormikSelectGroup = ({
         error={Boolean(error)}
         IconComponent={IconWithLoading}
       >
-        {loading ? (
-          <MenuItem disabled>
-            <CircularProgress size={20} />
-          </MenuItem>
-        ) : (
-          <>
-            {showSelectAll && options.length > 0 && (
-              <>
-                <MenuItem
-                  value="selectAll"
-                  sx={{
-                    backgroundColor: "#fafafa",
-                    "&:hover": {
-                      backgroundColor: "#f0f0f0"
-                    }
-                  }}
-                  onClick={() => {
-                    // custom event value to select all
-                    handleChange({ target: { value: ["selectAll"] } });
-                  }}
-                >
-                  <Checkbox
-                    checked={isAllSelected}
-                    indeterminate={selectedValues.length > 0 && !isAllSelected}
-                    sx={{
-                      p: 1,
-                      "& svg": {
-                        fontSize: 24
-                      }
-                    }}
-                  />
-                  <ListItemText
-                    primary={selectAllLabel}
-                    slotProps={{
-                      primary: {
-                        sx: {
-                          fontSize: "16px"
-                        }
-                      }
-                    }}
-                  />
-                </MenuItem>
-                <Divider />
-              </>
-            )}
-            {renderGroupedOptions()}
-          </>
-        )}
+        {renderMenuContent()}
       </Select>
       {error && (
         <div
@@ -318,6 +345,7 @@ MuiFormikSelectGroup.propTypes = {
   getOptionValue: PropTypes.func,
   getGroupId: PropTypes.func,
   getGroupLabel: PropTypes.func,
+  noOptionsLabel: PropTypes.string,
   disabled: PropTypes.bool
 };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,7 @@
     "user_not_authz": "Hold on. Your user is not authorized!.",
     "user_not_set": "Hold on. Can not get any valid user.",
     "session_expired": "Hold on. Your session expired!.",
-    "empty_list": "there not are any item that match your criteria.",
+    "empty_list": "there not are any {item} that match your criteria.",
     "server_error": "There was a problem with our server, please contact admin.",
     "empty_list_schedule_events": "Please select a Day and a Location ...",
     "not_allowed": "You are not allowed here, please login with another user to access this page.",
@@ -2480,6 +2480,7 @@
       "archive": "Archive",
       "unarchive": "Unarchive",
       "no_add_ons": "No Add-ons Available",
+      "no_pages": "There is no pages that match the criteria",
       "add_page_using_template": "Add Page Template",
       "add_selected_page_template": "Add Selected Page Template"
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2476,7 +2476,10 @@
       "upload_mod": "Upload Mod",
       "download_mod": "Download Mod",
       "archive": "Archive",
-      "unarchive": "Unarchive"
+      "unarchive": "Unarchive",
+      "no_add_ons": "No Add-ons Available",
+      "add_page_using_template": "Add Page Template",
+      "add_selected_page_template": "Add Selected Page Template"
     },
     "cart_tab": {
       "new_form": "New Form",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -97,7 +97,8 @@
     "date": "Wrong date format.",
     "after": "'{field1}' must be after '{field2}'.",
     "boolean": "Must be a boolean.",
-    "mib_aligned": "Must be a MiB aligned value"
+    "mib_aligned": "Must be a MiB aligned value",
+    "add_on_required": "Select at least one add-on"
   },
   "landing": {
     "os_summit_admin": "Show Admin",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,6 +75,7 @@
     "error": "Error!",
     "unarchive": "Unarchive",
     "archive": "Archive",
+    "sort_by": "Sort By",
     "sort_asc_label": "A-Z",
     "sort_desc_label": "Z-A",
     "placeholders": {
@@ -2480,6 +2481,7 @@
       "download_mod": "Download Mod",
       "archive": "Archive",
       "unarchive": "Unarchive",
+      "items_selected": "items selected",
       "no_add_ons": "No Add-ons Available",
       "no_pages": "There is no pages that match the criteria",
       "add_page_using_template": "Add Page Template",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,6 +75,8 @@
     "error": "Error!",
     "unarchive": "Unarchive",
     "archive": "Archive",
+    "sort_asc_label": "A-Z",
+    "sort_desc_label": "Z-A",
     "placeholders": {
       "search_speakers": "Search Speakers by Name, Email, Speaker Id or Member Id",
       "select_acceptance_criteria": "Select acceptance criteria",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,7 @@
     "user_not_authz": "Hold on. Your user is not authorized!.",
     "user_not_set": "Hold on. Can not get any valid user.",
     "session_expired": "Hold on. Your session expired!.",
-    "empty_list": "There are no {item} that match your criteria.",
+    "empty_list": "there not are any item that match your criteria.",
     "server_error": "There was a problem with our server, please contact admin.",
     "empty_list_schedule_events": "Please select a Day and a Location ...",
     "not_allowed": "You are not allowed here, please login with another user to access this page.",
@@ -2485,7 +2485,8 @@
       "no_add_ons": "No Add-ons Available",
       "no_pages": "There are no pages that match the criteria",
       "add_page_using_template": "Add Page Template",
-      "add_selected_page_template": "Add Selected Page Template"
+      "add_selected_page_template": "Add Selected Page Template",
+      "managed_page_saved": "Managed Page updated successfully."
     },
     "cart_tab": {
       "new_form": "New Form",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3,7 +3,7 @@
     "user_not_authz": "Hold on. Your user is not authorized!.",
     "user_not_set": "Hold on. Can not get any valid user.",
     "session_expired": "Hold on. Your session expired!.",
-    "empty_list": "there not are any {item} that match your criteria.",
+    "empty_list": "There are no {item} that match your criteria.",
     "server_error": "There was a problem with our server, please contact admin.",
     "empty_list_schedule_events": "Please select a Day and a Location ...",
     "not_allowed": "You are not allowed here, please login with another user to access this page.",
@@ -2483,7 +2483,7 @@
       "unarchive": "Unarchive",
       "items_selected": "items selected",
       "no_add_ons": "No Add-ons Available",
-      "no_pages": "There is no pages that match the criteria",
+      "no_pages": "There are no pages that match the criteria",
       "add_page_using_template": "Add Page Template",
       "add_selected_page_template": "Add Selected Page Template"
     },

--- a/src/pages/sponsors-global/form-templates/add-form-template-item-popup.js
+++ b/src/pages/sponsors-global/form-templates/add-form-template-item-popup.js
@@ -206,11 +206,18 @@ const AddFormTemplateItemDialog = ({
                   //   onClick: () => handleSort("date", "+")
                   // },
                   // { label: "Newest", onClick: () => handleSort("date", "+") },
-                  { label: "A-Z", onClick: () => handleSort("name", 1) },
-                  { label: "Z-A", onClick: () => handleSort("name", 0) }
+                  {
+                    label: T.translate("general.sort_asc_label"),
+                    onClick: () => handleSort("name", 1)
+                  },
+                  {
+                    label: T.translate("general.sort_desc_label"),
+                    onClick: () => handleSort("name", 0)
+                  }
                 ]}
               >
-                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} />{" "}
+                {T.translate("general.sort_by")}
               </MenuButton>
             </Grid2>
             <Grid2 size={8}>

--- a/src/pages/sponsors-global/form-templates/form-template-from-duplicate-popup.js
+++ b/src/pages/sponsors-global/form-templates/form-template-from-duplicate-popup.js
@@ -119,11 +119,18 @@ const FormTemplateFromDuplicateDialog = ({
                 buttonSx={{ color: "#000" }}
                 menuItems={[
                   // { label: "Newest", onClick: () => handleSort("+date") },
-                  { label: "A-Z", onClick: () => handleSort("name", 1) },
-                  { label: "Z-A", onClick: () => handleSort("name", 0) }
+                  {
+                    label: T.translate("general.sort_asc_label"),
+                    onClick: () => handleSort("name", 1)
+                  },
+                  {
+                    label: T.translate("general.sort_desc_label"),
+                    onClick: () => handleSort("name", 0)
+                  }
                 ]}
               >
-                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} />{" "}
+                {T.translate("general.sort_by")}
               </MenuButton>
             </Grid2>
             <Grid2 size={8}>

--- a/src/pages/sponsors/sponsor-forms-tab/components/add-sponsor-form-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-forms-tab/components/add-sponsor-form-template-popup/index.js
@@ -227,11 +227,18 @@ const AddSponsorFormTemplatePopup = ({
                     buttonId="sort-button"
                     menuId="sort-menu"
                     menuItems={[
-                      { label: "A-Z", onClick: () => handleSort("name", 1) },
-                      { label: "Z-A", onClick: () => handleSort("name", 0) }
+                      {
+                        label: T.translate("general.sort_asc_label"),
+                        onClick: () => handleSort("name", 1)
+                      },
+                      {
+                        label: T.translate("general.sort_desc_label"),
+                        onClick: () => handleSort("name", 0)
+                      }
                     ]}
                   >
-                    <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                    <SwapVertIcon fontSize="large" sx={{ mr: 1 }} />{" "}
+                    {T.translate("general.sort_by")}
                   </MenuButton>
                 </Grid2>
                 <Grid2 size={8}>

--- a/src/pages/sponsors/sponsor-forms-tab/components/manage-items/sponsor-form-item-from-inventory.js
+++ b/src/pages/sponsors/sponsor-forms-tab/components/manage-items/sponsor-form-item-from-inventory.js
@@ -220,7 +220,8 @@ const SponsorFormItemFromInventoryPopup = ({
                   }
                 ]}
               >
-                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                <SwapVertIcon fontSize="large" sx={{ mr: 1 }} />{" "}
+                {T.translate("general.sort_by")}
               </MenuButton>
             </Grid2>
             <Grid2 size={9}>

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -26,13 +26,16 @@ import MuiTable from "../../../../../components/mui/table/mui-table";
 import MenuButton from "../../../../../components/mui/menu-button";
 import { querySponsorAddons } from "../../../../../actions/sponsor-actions";
 import { getShowPages } from "../../../../../actions/show-pages-actions";
-import { FIVE_PER_PAGE } from "../../../../../utils/constants";
+import {
+  DEFAULT_CURRENT_PAGE,
+  FIVE_PER_PAGE
+} from "../../../../../utils/constants";
 import MuiFormikSelectGroup from "../../../../../components/mui/formik-inputs/mui-formik-select-group";
 
 const AddSponsorPageTemplatePopup = ({
   onClose,
   onSubmit,
-  sponsorPages,
+  showPages,
   currentPage,
   perPage,
   order,
@@ -77,7 +80,7 @@ const AddSponsorPageTemplatePopup = ({
   useEffect(() => {
     getShowPages(
       term,
-      currentPage,
+      DEFAULT_CURRENT_PAGE,
       FIVE_PER_PAGE,
       order,
       orderDir,
@@ -101,7 +104,7 @@ const AddSponsorPageTemplatePopup = ({
   const handleSort = (key, dir) => {
     getShowPages(
       term,
-      currentPage,
+      DEFAULT_CURRENT_PAGE,
       FIVE_PER_PAGE,
       key,
       dir,
@@ -114,7 +117,7 @@ const AddSponsorPageTemplatePopup = ({
     if (ev.key === "Enter")
       getShowPages(
         searchTerm,
-        currentPage,
+        DEFAULT_CURRENT_PAGE,
         perPage,
         order,
         orderDir,
@@ -234,8 +237,14 @@ const AddSponsorPageTemplatePopup = ({
                     buttonId="sort-button"
                     menuId="sort-menu"
                     menuItems={[
-                      { label: "A-Z", onClick: () => handleSort("name", 1) },
-                      { label: "Z-A", onClick: () => handleSort("name", 0) }
+                      {
+                        label: T.translate("general.sort_asc_label"),
+                        onClick: () => handleSort("name", 1)
+                      },
+                      {
+                        label: T.translate("general.sort_desc_label"),
+                        onClick: () => handleSort("name", 0)
+                      }
                     ]}
                   >
                     <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
@@ -266,11 +275,11 @@ const AddSponsorPageTemplatePopup = ({
               </Grid2>
             </Grid2>
 
-            {sponsorPages.length > 0 && (
+            {showPages.length > 0 && (
               <Box sx={{ p: 2 }}>
                 <MuiTable
                   columns={columns}
-                  data={sponsorPages}
+                  data={showPages}
                   options={tableOptions}
                   currentPage={currentPage}
                   perPage={perPage}
@@ -302,8 +311,8 @@ AddSponsorPageTemplatePopup.propTypes = {
   onClose: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ sponsorPagesListState }) => ({
-  ...sponsorPagesListState
+const mapStateToProps = ({ showPagesListState }) => ({
+  ...showPagesListState
 });
 
 export default connect(mapStateToProps, {

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -232,7 +232,10 @@ const AddSponsorPageTemplatePopup = ({
                 size={6}
                 sx={{ alignItems: "baseline" }}
               >
-                <Grid2 size={4}>{selectedPages.length} items selected</Grid2>
+                <Grid2 size={4}>
+                  {selectedPages.length}{" "}
+                  {T.translate("edit_sponsor.pages_tab.items_selected")}
+                </Grid2>
               </Grid2>
               <Grid2 container spacing={2} size={6}>
                 <Grid2 size={4}>
@@ -250,7 +253,8 @@ const AddSponsorPageTemplatePopup = ({
                       }
                     ]}
                   >
-                    <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                    <SwapVertIcon fontSize="large" sx={{ mr: 1 }} />{" "}
+                    {T.translate("general.sort_by")}
                   </MenuButton>
                 </Grid2>
                 <Grid2 size={8}>
@@ -294,7 +298,7 @@ const AddSponsorPageTemplatePopup = ({
             )}
             {showPages.length === 0 && (
               <Box sx={{ p: 2 }}>
-                {T.translate("errors.pages_tab.no_pages")}
+                {T.translate("edit_sponsor.pages_tab.no_pages")}
               </Box>
             )}
           </DialogContent>

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -114,7 +114,9 @@ const AddSponsorPageTemplatePopup = ({
   };
 
   const handleOnSearch = (ev) => {
-    if (ev.key === "Enter")
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      ev.stopPropagation();
       getShowPages(
         searchTerm,
         DEFAULT_CURRENT_PAGE,
@@ -124,6 +126,7 @@ const AddSponsorPageTemplatePopup = ({
         false,
         sponsorshipTypeIds
       );
+    }
   };
 
   const handleSelected = (id, isSelected) => {
@@ -287,6 +290,11 @@ const AddSponsorPageTemplatePopup = ({
                   onSort={handleSort}
                   onPageChange={handlePageChange}
                 />
+              </Box>
+            )}
+            {showPages.length === 0 && (
+              <Box sx={{ p: 2 }}>
+                {T.translate("errors.pages_tab.no_pages")}
               </Box>
             )}
           </DialogContent>

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
 import React, { useEffect, useState } from "react";
 import T from "i18n-react/dist/i18n-react";
 import { connect } from "react-redux";

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -1,0 +1,311 @@
+import React, { useEffect, useState } from "react";
+import T from "i18n-react/dist/i18n-react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  Grid2,
+  IconButton,
+  TextField,
+  Typography
+} from "@mui/material";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import SearchIcon from "@mui/icons-material/Search";
+import CloseIcon from "@mui/icons-material/Close";
+import * as yup from "yup";
+import { FormikProvider, useFormik } from "formik";
+import MuiTable from "../../../../../components/mui/table/mui-table";
+import MenuButton from "../../../../../components/mui/menu-button";
+import { querySponsorAddons } from "../../../../../actions/sponsor-actions";
+import { getShowPages } from "../../../../../actions/show-pages-actions";
+import { FIVE_PER_PAGE } from "../../../../../utils/constants";
+import MuiFormikSelectGroup from "../../../../../components/mui/formik-inputs/mui-formik-select-group";
+
+const AddSponsorPageTemplatePopup = ({
+  onClose,
+  onSubmit,
+  sponsorPages,
+  currentPage,
+  perPage,
+  order,
+  orderDir,
+  totalCount,
+  term = "",
+  getShowPages,
+  sponsor,
+  summitId
+}) => {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedPages, setSelectedPages] = useState([]);
+
+  const sponsorshipIds = sponsor.sponsorships.map((e) => e.id);
+
+  const sponsorshipTypeIds = sponsor.sponsorships.map((e) => e.type.id);
+
+  const formik = useFormik({
+    initialValues: {
+      add_ons: []
+    },
+    validationSchema: yup.object({
+      add_ons: yup
+        .array()
+        .test(
+          "add_ons-required",
+          "Select at least one add-on",
+          (value) => value?.includes("all") || value?.length > 0
+        )
+    }),
+    onSubmit: (values) => {
+      const { add_ons } = values;
+      const entity = {
+        pages: selectedPages,
+        add_ons
+      };
+      onSubmit(entity);
+    },
+    enableReinitialize: true
+  });
+
+  useEffect(() => {
+    getShowPages(
+      term,
+      currentPage,
+      FIVE_PER_PAGE,
+      order,
+      orderDir,
+      false,
+      sponsorshipTypeIds
+    );
+  }, []);
+
+  const handlePageChange = (page) => {
+    getShowPages(
+      term,
+      page,
+      FIVE_PER_PAGE,
+      order,
+      orderDir,
+      false,
+      sponsorshipTypeIds
+    );
+  };
+
+  const handleSort = (key, dir) => {
+    getShowPages(
+      term,
+      currentPage,
+      FIVE_PER_PAGE,
+      key,
+      dir,
+      false,
+      sponsorshipTypeIds
+    );
+  };
+
+  const handleOnSearch = (ev) => {
+    if (ev.key === "Enter")
+      getShowPages(
+        searchTerm,
+        currentPage,
+        perPage,
+        order,
+        orderDir,
+        false,
+        sponsorshipTypeIds
+      );
+  };
+
+  const handleSelected = (id, isSelected) => {
+    if (isSelected) {
+      setSelectedPages([...selectedPages, id]);
+      return;
+    }
+    const updatedSelected = selectedPages.filter((e) => e !== id);
+    setSelectedPages(updatedSelected);
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const tableOptions = {
+    sortCol: order,
+    sortDir: orderDir
+  };
+
+  const columns = [
+    {
+      columnKey: "select",
+      header: "",
+      width: 30,
+      align: "center",
+      render: (row) => (
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={selectedPages.includes(row.id)}
+              onChange={(ev) => handleSelected(row.id, ev.target.checked)}
+            />
+          }
+        />
+      )
+    },
+    {
+      columnKey: "code",
+      header: T.translate("edit_sponsor.pages_tab.code"),
+      sortable: false
+    },
+    {
+      columnKey: "name",
+      header: T.translate("edit_sponsor.pages_tab.name"),
+      sortable: false
+    },
+    {
+      columnKey: "info_mod",
+      header: T.translate("edit_sponsor.pages_tab.info_mod")
+    },
+    {
+      columnKey: "upload_mod",
+      header: T.translate("edit_sponsor.pages_tab.upload_mod")
+    },
+    {
+      columnKey: "download_mod",
+      header: T.translate("edit_sponsor.pages_tab.download_mod")
+    }
+  ];
+
+  return (
+    <Dialog open onClose={handleClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Typography fontSize="1.5rem">
+          {T.translate("edit_sponsor.pages_tab.add_page_using_template")}
+        </Typography>
+        <IconButton size="small" onClick={() => handleClose()} sx={{ mr: 1 }}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <Divider />
+      <FormikProvider value={formik}>
+        <Box
+          component="form"
+          onSubmit={formik.handleSubmit}
+          noValidate
+          autoComplete="off"
+        >
+          <DialogContent sx={{ p: 0 }}>
+            <Grid2 container spacing={2} size={12} sx={{ p: 2 }}>
+              <MuiFormikSelectGroup
+                name="add_ons"
+                formik={formik}
+                queryFunction={querySponsorAddons}
+                // params for function, except input
+                queryParams={[summitId, sponsor.id, sponsorshipIds]}
+                showSelectAll
+                getGroupId={(addon) => addon.sponsorship.type.id}
+                getGroupLabel={(addon) => addon.sponsorship.type.type.name}
+                noOptionsLabel={T.translate(
+                  "edit_sponsor.pages_tab.no_add_ons"
+                )}
+                placeholder={T.translate(
+                  "edit_sponsor.placeholders.select_add_ons"
+                )}
+              />
+            </Grid2>
+            <Grid2 container spacing={2} size={12} sx={{ p: 2 }}>
+              <Grid2
+                container
+                spacing={2}
+                size={6}
+                sx={{ alignItems: "baseline" }}
+              >
+                <Grid2 size={4}>{selectedPages.length} items selected</Grid2>
+              </Grid2>
+              <Grid2 container spacing={2} size={6}>
+                <Grid2 size={4}>
+                  <MenuButton
+                    buttonId="sort-button"
+                    menuId="sort-menu"
+                    menuItems={[
+                      { label: "A-Z", onClick: () => handleSort("name", 1) },
+                      { label: "Z-A", onClick: () => handleSort("name", 0) }
+                    ]}
+                  >
+                    <SwapVertIcon fontSize="large" sx={{ mr: 1 }} /> sort by
+                  </MenuButton>
+                </Grid2>
+                <Grid2 size={8}>
+                  <TextField
+                    variant="outlined"
+                    value={searchTerm}
+                    placeholder={T.translate(
+                      "edit_sponsor.placeholders.search"
+                    )}
+                    slotProps={{
+                      input: {
+                        startAdornment: <SearchIcon sx={{ mr: 1 }} />
+                      }
+                    }}
+                    onChange={(event) => setSearchTerm(event.target.value)}
+                    onKeyDown={handleOnSearch}
+                    fullWidth
+                    sx={{
+                      "& .MuiOutlinedInput-root": {
+                        height: "36px"
+                      }
+                    }}
+                  />
+                </Grid2>
+              </Grid2>
+            </Grid2>
+
+            {sponsorPages.length > 0 && (
+              <Box sx={{ p: 2 }}>
+                <MuiTable
+                  columns={columns}
+                  data={sponsorPages}
+                  options={tableOptions}
+                  currentPage={currentPage}
+                  perPage={perPage}
+                  totalRows={totalCount}
+                  onSort={handleSort}
+                  onPageChange={handlePageChange}
+                />
+              </Box>
+            )}
+          </DialogContent>
+          <Divider />
+          <DialogActions>
+            <Button
+              type="submit"
+              disabled={selectedPages.length === 0}
+              fullWidth
+              variant="contained"
+            >
+              {T.translate("edit_sponsor.pages_tab.add_selected_page_template")}
+            </Button>
+          </DialogActions>
+        </Box>
+      </FormikProvider>
+    </Dialog>
+  );
+};
+
+AddSponsorPageTemplatePopup.propTypes = {
+  onClose: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ sponsorPagesListState }) => ({
+  ...sponsorPagesListState
+});
+
+export default connect(mapStateToProps, {
+  getShowPages
+})(AddSponsorPageTemplatePopup);

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -62,7 +62,7 @@ const AddSponsorPageTemplatePopup = ({
         .array()
         .test(
           "add_ons-required",
-          "Select at least one add-on",
+          T.translate("validation.add_on_required"),
           (value) => value?.includes("all") || value?.length > 0
         )
     }),

--- a/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/components/add-sponsor-page-template-popup/index.js
@@ -133,7 +133,7 @@ const AddSponsorPageTemplatePopup = ({
       getShowPages(
         searchTerm,
         DEFAULT_CURRENT_PAGE,
-        perPage,
+        FIVE_PER_PAGE,
         order,
         orderDir,
         false,

--- a/src/pages/sponsors/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/index.js
@@ -193,10 +193,9 @@ const SponsorPagesTab = ({
   };
 
   const handleSaveManagedPageFromTemplate = (entity) => {
-    saveSponsorManagedPage(entity).then(() => {
-      setOpenPopup(null);
-      getSponsorManagedPages();
-    });
+    saveSponsorManagedPage(entity)
+      .then(() => getSponsorManagedPages())
+      .finally(() => setOpenPopup(null));
   };
 
   const baseColumns = (name) => [

--- a/src/pages/sponsors/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/index.js
@@ -11,7 +11,7 @@
  * limitations under the License.
  * */
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import T from "i18n-react/dist/i18n-react";
 import {
@@ -25,21 +25,28 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import {
   getSponsorManagedPages,
-  getSponsorCustomizedPages
+  getSponsorCustomizedPages,
+  saveSponsorManagedPage
 } from "../../../actions/sponsor-pages-actions";
 import CustomAlert from "../../../components/mui/custom-alert";
 import SearchInput from "../../../components/mui/search-input";
 import MuiTable from "../../../components/mui/table/mui-table";
 import { DEFAULT_CURRENT_PAGE } from "../../../utils/constants";
+import AddSponsorPageTemplatePopup from "./components/add-sponsor-page-template-popup";
 
 const SponsorPagesTab = ({
+  sponsor,
+  summitId,
   term,
   hideArchived,
   managedPages,
   customizedPages,
   getSponsorManagedPages,
-  getSponsorCustomizedPages
+  getSponsorCustomizedPages,
+  saveSponsorManagedPage
 }) => {
+  const [openPopup, setOpenPopup] = useState(null);
+
   useEffect(() => {
     getSponsorManagedPages();
     getSponsorCustomizedPages();
@@ -140,6 +147,10 @@ const SponsorPagesTab = ({
     );
   };
 
+  const handleUsingTemplate = () => {
+    setOpenPopup("template");
+  };
+
   const handleArchiveCustomizedPage = (item) =>
     console.log("ARCHIVE CUSTOMIZED ", item);
 
@@ -179,6 +190,13 @@ const SponsorPagesTab = ({
       customizedPages.orderDir,
       ev.target.checked
     );
+  };
+
+  const handleSaveManagedPageFromTemplate = (entity) => {
+    saveSponsorManagedPage(entity).then(() => {
+      setOpenPopup(null);
+      getSponsorManagedPages();
+    });
   };
 
   const baseColumns = (name) => [
@@ -276,7 +294,7 @@ const SponsorPagesTab = ({
             variant="contained"
             size="medium"
             fullWidth
-            onClick={() => console.log("open popup template")}
+            onClick={handleUsingTemplate}
             startIcon={<AddIcon />}
             sx={{ height: "36px" }}
           >
@@ -336,6 +354,15 @@ const SponsorPagesTab = ({
           onArchive={handleArchiveManagedPage}
         />
       </div>
+
+      {openPopup === "template" && (
+        <AddSponsorPageTemplatePopup
+          sponsor={sponsor}
+          summitId={summitId}
+          onSubmit={handleSaveManagedPageFromTemplate}
+          onClose={() => setOpenPopup(null)}
+        />
+      )}
     </Box>
   );
 };
@@ -346,5 +373,6 @@ const mapStateToProps = ({ sponsorPagePagesListState }) => ({
 
 export default connect(mapStateToProps, {
   getSponsorManagedPages,
+  saveSponsorManagedPage,
   getSponsorCustomizedPages
 })(SponsorPagesTab);

--- a/src/pages/sponsors/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/index.js
@@ -276,7 +276,7 @@ const SponsorPagesTab = ({
             variant="contained"
             size="medium"
             fullWidth
-            onClick={() => setOpenPopup("template")}
+            onClick={() => console.log("open popup template")}
             startIcon={<AddIcon />}
             sx={{ height: "36px" }}
           >
@@ -288,7 +288,7 @@ const SponsorPagesTab = ({
             variant="contained"
             size="medium"
             fullWidth
-            onClick={() => setCustomFormEdit("new")}
+            onClick={() => console.log("open popup new")}
             startIcon={<AddIcon />}
             sx={{ height: "36px" }}
           >

--- a/src/pages/sponsors/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-pages-tab/index.js
@@ -276,7 +276,7 @@ const SponsorPagesTab = ({
             variant="contained"
             size="medium"
             fullWidth
-            onClick={() => console.log("open popup template")}
+            onClick={() => setOpenPopup("template")}
             startIcon={<AddIcon />}
             sx={{ height: "36px" }}
           >
@@ -288,7 +288,7 @@ const SponsorPagesTab = ({
             variant="contained"
             size="medium"
             fullWidth
-            onClick={() => console.log("open popup new")}
+            onClick={() => setCustomFormEdit("new")}
             startIcon={<AddIcon />}
             sx={{ height: "36px" }}
           >


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b7991c2

Signed-off-by: Tomás Castillo [tcastilloboireau@gmail.com](mailto:tcastilloboireau@gmail.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add pages from templates via a modal: bulk page selection, add-on selection (supports "all"), sorting, searching, pagination, and direct save of managed pages from the template workflow.

* **UI/UX Improvements**
  * Select controls show customizable "no items" text and improved menu states (loading / empty / grouped options).
  * "Using template" now opens the template workflow.

* **Localization**
  * Added A–Z / Z–A sort labels, new page-tab strings, and updated validation/empty-list messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->