### PR TITLE
fix: adding trailing 0 when only 1 decimal on price input

### DIFF
--- a/src/components/mui/formik-inputs/mui-formik-pricefield.js
+++ b/src/components/mui/formik-inputs/mui-formik-pricefield.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { InputAdornment } from "@mui/material";
 import { useField } from "formik";
 import MuiFormikTextField from "./mui-formik-textfield";
-import { ONE_HUNDRED } from "../../../utils/constants";
+import { DECIMAL_DIGITS, ONE_HUNDRED } from "../../../utils/constants";
 
 const BLOCKED_KEYS = ["e", "E", "+", "-"];
 
@@ -25,7 +25,11 @@ const MuiFormikPriceField = ({
     if (field.value == null || field.value === 0) {
       return field.value === 0 ? 0 : "";
     }
-    return inCents ? field.value / ONE_HUNDRED : field.value;
+    const raw = inCents ? field.value / ONE_HUNDRED : field.value;
+    const str = String(Number(raw.toFixed(DECIMAL_DIGITS)));
+    const dotIdx = str.indexOf(".");
+    if (dotIdx !== -1 && str.length - dotIdx - 1 === 1) return `${str}0`;
+    return str;
   };
 
   const handleChange = (e) => {
@@ -39,7 +43,9 @@ const MuiFormikPriceField = ({
 
     setCleared(false);
     const numericValue = Number(newVal);
-    const newPrice = inCents ? numericValue * ONE_HUNDRED : numericValue;
+    const newPrice = inCents
+      ? Math.round(numericValue * ONE_HUNDRED)
+      : numericValue;
 
     helpers.setValue(newPrice);
   };


### PR DESCRIPTION
https://app.clickup.com/t/86b916bzq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Price field now displays and calculates decimal values more accurately with improved rounding for currency inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->