### PR TITLE
fix: media uploads grid spinner

### DIFF
--- a/src/pages/events/__tests__/summit-event-list-page.test.js
+++ b/src/pages/events/__tests__/summit-event-list-page.test.js
@@ -200,6 +200,81 @@ describe("SummitEventListPage", () => {
     );
   });
 
+  test("opens media upload material link using current summit id fallback", async () => {
+    renderWithRedux(<SummitEventListPage />, {
+      initialState: {
+        currentSummitState: {
+          currentSummit: {
+            id: 12,
+            time_zone: { name: "UTC" },
+            time_zone_id: "UTC",
+            selection_plans: [],
+            tracks: [],
+            event_types: [],
+            locations: [],
+            presentation_action_types: []
+          }
+        },
+        currentEventListState: {
+          events: [
+            {
+              id: 101,
+              type: { id: 1, name: "Presentation", use_speakers: true },
+              title: "Sample event",
+              selection_status: "pending",
+              media_uploads: [
+                {
+                  id: 999,
+                  created: "now",
+                  media_upload_type: { name: "Slides" }
+                }
+              ]
+            }
+          ],
+          lastPage: 1,
+          currentPage: 1,
+          order: "id",
+          orderDir: 1,
+          totalEvents: 1,
+          term: "",
+          filters: {},
+          extraColumns: ["media_uploads"],
+          perPage: 10,
+          enabledFilters: []
+        }
+      }
+    });
+
+    const editableTableProps =
+      mockEditableTableSpy.mock.calls[
+        mockEditableTableSpy.mock.calls.length - 1
+      ][0];
+    const mediaUploadsColumn = editableTableProps.columns.find(
+      (col) => col.columnKey === "media_uploads"
+    );
+
+    const mediaUploadItem = {
+      id: 999,
+      created: "now",
+      media_upload_type: { name: "Slides" }
+    };
+
+    const rendered = mediaUploadsColumn.render([mediaUploadItem], { id: 101 });
+    const firstRow = rendered.props.children[0];
+    const firstButton = Array.isArray(firstRow.props.children)
+      ? firstRow.props.children[0]
+      : firstRow.props.children;
+
+    firstButton.props.onClick({
+      preventDefault: jest.fn()
+    });
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      "/app/summits/12/events/101/materials/999",
+      "_blank"
+    );
+  });
+
   test("does not open media upload material link when row event id is missing", async () => {
     renderWithRedux(<SummitEventListPage />, {
       initialState: {

--- a/src/pages/events/summit-event-list-page.js
+++ b/src/pages/events/summit-event-list-page.js
@@ -69,7 +69,12 @@ import {
 import { CONTEXT_ACTIVITIES } from "../../utils/filter-criteria-constants";
 import EditableTable from "../../components/tables/editable-table/EditableTable";
 
-const fieldNames = (allSelectionPlans, allTracks, event_types) => [
+const fieldNames = (
+  allSelectionPlans,
+  allTracks,
+  event_types,
+  currentSummitId
+) => [
   {
     columnKey: "speakers",
     value: "speakers",
@@ -263,9 +268,11 @@ const fieldNames = (allSelectionPlans, allTracks, event_types) => [
                 className="text-link-button"
                 onClick={(ev) => {
                   ev.preventDefault();
-                  if (!row?.id) return false;
+                  const summitId =
+                    m?.summit_id || row?.summit_id || currentSummitId;
+                  if (!row?.id || !summitId) return false;
                   window.open(
-                    `/app/summits/${m.summit_id}/events/${row.id}/materials/${m.id}`,
+                    `/app/summits/${summitId}/events/${row.id}/materials/${m.id}`,
                     "_blank"
                   );
                   return false;
@@ -1238,7 +1245,8 @@ class SummitEventListPage extends React.Component {
     const showColumns = fieldNames(
       currentSummit.selection_plans,
       currentSummit.tracks,
-      currentSummit.event_types
+      currentSummit.event_types,
+      currentSummit.id
     )
       .filter(
         (f) =>

--- a/src/pages/events/summit-event-list-page.js
+++ b/src/pages/events/summit-event-list-page.js
@@ -268,7 +268,7 @@ const fieldNames = (
                 className="text-link-button"
                 onClick={(ev) => {
                   ev.preventDefault();
-                  if (!row?.id) return false;
+                  if (!row?.id || !currentSummitId) return false;
                   window.open(
                     `/app/summits/${currentSummitId}/events/${row.id}/materials/${m.id}`,
                     "_blank"

--- a/src/pages/events/summit-event-list-page.js
+++ b/src/pages/events/summit-event-list-page.js
@@ -268,11 +268,9 @@ const fieldNames = (
                 className="text-link-button"
                 onClick={(ev) => {
                   ev.preventDefault();
-                  const summitId =
-                    m?.summit_id || row?.summit_id || currentSummitId;
-                  if (!row?.id || !summitId) return false;
+                  if (!row?.id) return false;
                   window.open(
-                    `/app/summits/${summitId}/events/${row.id}/materials/${m.id}`,
+                    `/app/summits/${currentSummitId}/events/${row.id}/materials/${m.id}`,
                     "_blank"
                   );
                   return false;


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b90w2rq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Media upload materials links now consistently open in a new tab using the current summit ID when records lack embedded summit/presentation/event identifiers, ensuring reliable navigation.

* **Tests**
  * Added a test verifying the materials link opens in a new tab with the fallback summit ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->