### PR TITLE
fix: append .00 when integer

### DIFF
--- a/src/components/mui/formik-inputs/mui-formik-pricefield.js
+++ b/src/components/mui/formik-inputs/mui-formik-pricefield.js
@@ -38,7 +38,8 @@ const MuiFormikPriceField = ({
     }
     const str = getRawString();
     const dotIdx = str.indexOf(".");
-    if (dotIdx !== -1 && str.length - dotIdx - 1 === 1) return `${str}0`;
+    if (dotIdx === -1) return `${str}.00`;
+    if (str.length - dotIdx - 1 === 1) return `${str}0`;
     return str;
   };
 


### PR DESCRIPTION
https://app.clickup.com/t/86b916bzq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced price field display formatting to ensure consistent representation with two decimal places. Price values without a decimal point now correctly display the `.00` suffix, improving consistency across all price entry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->