### PR TITLE
fix: add input search field on show pages list page

### DIFF
--- a/src/pages/sponsors/show-pages-list-page/index.js
+++ b/src/pages/sponsors/show-pages-list-page/index.js
@@ -37,6 +37,7 @@ import CustomAlert from "../../../components/mui/custom-alert";
 import MuiTable from "../../../components/mui/table/mui-table";
 import GlobalPagePopup from "./components/global-page/global-page-popup";
 import PageTemplatePopup from "../../sponsors-global/page-templates/page-template-popup";
+import SearchInput from "../../../components/mui/search-input";
 import { DEFAULT_CURRENT_PAGE, MAX_PER_PAGE } from "../../../utils/constants";
 
 const ShowPagesListPage = ({
@@ -101,6 +102,17 @@ const ShowPagesListPage = ({
       order,
       orderDir,
       ev.target.checked
+    );
+  };
+
+  const handleSearch = (searchTerm) => {
+    getShowPages(
+      searchTerm,
+      DEFAULT_CURRENT_PAGE,
+      perPage,
+      order,
+      orderDir,
+      hideArchived
     );
   };
 
@@ -199,7 +211,13 @@ const ShowPagesListPage = ({
             />
           </FormGroup>
         </Grid2>
-        <Grid2 size={2} />
+        <Grid2 size={2}>
+          <SearchInput
+            term={term}
+            onSearch={handleSearch}
+            placeholder={T.translate("show_pages.placeholders.search")}
+          />
+        </Grid2>
         <Grid2 size={3}>
           <Button
             variant="contained"


### PR DESCRIPTION

<img width="1201" height="830" alt="image" src="https://github.com/user-attachments/assets/0e65a95b-a8ec-4f1a-856e-adc4f7f29483" />

ref: https://app.clickup.com/t/86b96pbpc

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added search functionality to the show pages list. Users can now enter search terms to filter results while preserving existing filters and sorting preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->