### PR TITLE
fix: adjust delete popup text message on show pages

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2746,6 +2746,7 @@
     "no_sponsors_pages": "No pages found for this search criteria.",
     "page_saved": "Page updated successfully.",
     "page_created": "Page created successfully.",
+    "page_delete_warning": "Please verify you want to delete {page}",
     "page_delete_success": "Page successfully deleted.",
     "placeholders": {
       "search": "Search..."

--- a/src/pages/sponsors/show-pages-list-page/index.js
+++ b/src/pages/sponsors/show-pages-list-page/index.js
@@ -240,6 +240,9 @@ const ShowPagesListPage = ({
             totalRows={totalCount}
             currentPage={currentPage}
             onDelete={handleRowDelete}
+            deleteDialogBody={(item) =>
+              T.translate("show_pages.page_delete_warning", { page: item })
+            }
             onPageChange={handlePageChange}
             onPerPageChange={handlePerPageChange}
             onSort={handleSort}


### PR DESCRIPTION
<img width="1233" height="568" alt="image" src="https://github.com/user-attachments/assets/5f54d8d3-2f55-488b-8456-60c82f7338a1" />

ref: https://app.clickup.com/t/86b96p88h

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a delete confirmation dialog with a warning message when users delete pages, requiring verification before the action is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->