### PR TITLE
fix: change text on cart delete verification

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2514,6 +2514,7 @@
       "add_ons": "Add-ons",
       "items": "Items",
       "discount": "Discount",
+      "delete_form_confirm": "Please verify you want to delete {form}",
       "amount": "Amount",
       "manage_items": "Manage Items",
       "add_form": "Add Form",

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-cart-tab/components/cart-view.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-cart-tab/components/cart-view.js
@@ -193,6 +193,12 @@ const CartView = ({
             options={{}}
             onEdit={onEdit}
             onDelete={handleDelete}
+            deleteDialogBody={(formName) =>
+              T.translate("edit_sponsor.cart_tab.delete_form_confirm", {
+                form: formName ?? ""
+              })
+            }
+            confirmButtonColor="error"
           >
             <TotalRow
               columns={tableColumns}


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9b9jbe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized delete-confirmation message with a placeholder for the item name.
  * Sponsor cart delete dialogs now display the item name in the confirmation text and use an error-styled confirm button for clearer intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->