### PR TITLE
 fix: add missing per page change on sponsor form items

### DIFF
--- a/src/pages/sponsors-global/form-templates/form-template-item-list-page.js
+++ b/src/pages/sponsors-global/form-templates/form-template-item-list-page.js
@@ -101,6 +101,18 @@ const FormTemplateItemListPage = ({
     );
   };
 
+  const handlePerPageChange = (newPerPage) => {
+    getFormTemplateItems(
+      formTemplateId,
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir,
+      hideArchived
+    );
+  };
+
   const handleSort = (key, dir) => {
     getFormTemplateItems(
       formTemplateId,
@@ -295,6 +307,7 @@ const FormTemplateItemListPage = ({
             totalRows={totalFormTemplateItems}
             currentPage={currentPage}
             onPageChange={handlePageChange}
+            onPerPageChange={handlePerPageChange}
             onSort={handleSort}
             onEdit={handleRowEdit}
             onArchive={handleArchiveItem}

--- a/src/pages/sponsors/sponsor-form-item-list-page/index.js
+++ b/src/pages/sponsors/sponsor-form-item-list-page/index.js
@@ -70,6 +70,17 @@ const SponsorFormItemListPage = ({
     getSponsorFormItems(formId, page, perPage, order, orderDir, hideArchived);
   };
 
+  const handlePerPageChange = (newPerPage) => {
+    getSponsorFormItems(
+      formId,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir,
+      hideArchived
+    );
+  };
+
   const handleSort = (key, dir) => {
     getSponsorFormItems(formId, currentPage, perPage, key, dir, hideArchived);
   };
@@ -283,6 +294,7 @@ const SponsorFormItemListPage = ({
             currentPage={currentPage}
             onDelete={handleRowDelete}
             onPageChange={handlePageChange}
+            onPerPageChange={handlePerPageChange}
             onSort={handleSort}
             onCellChange={handleCellEdit}
             onEdit={handleRowEdit}

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
@@ -67,6 +67,18 @@ const SponsorFormsTab = ({
     getSponsorManagedForms(term, page, perPage, order, orderDir, hideArchived);
   };
 
+  const handleManagedPerPageChange = (newPerPage) => {
+    const { order, orderDir } = managedForms;
+    getSponsorManagedForms(
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir,
+      hideArchived
+    );
+  };
+
   const handleManagedSort = (key, dir) => {
     const { currentPage, perPage } = managedForms;
     getSponsorManagedForms(term, currentPage, perPage, key, dir, hideArchived);
@@ -78,6 +90,18 @@ const SponsorFormsTab = ({
       term,
       page,
       perPage,
+      order,
+      orderDir,
+      hideArchived
+    );
+  };
+
+  const handleCustomizedPerPageChange = (newPerPage) => {
+    const { order, orderDir } = customizedForms;
+    getSponsorCustomizedForms(
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
       order,
       orderDir,
       hideArchived
@@ -157,7 +181,8 @@ const SponsorFormsTab = ({
     );
   };
 
-  const handleSaveFormFromTemplate = (entity) => saveSponsorManagedForm(entity).then(() => {
+  const handleSaveFormFromTemplate = (entity) =>
+    saveSponsorManagedForm(entity).then(() => {
       const { perPage, order, orderDir } = managedForms;
       getSponsorManagedForms(
         term,
@@ -364,6 +389,7 @@ const SponsorFormsTab = ({
           totalRows={customizedForms.totalCount}
           currentPage={customizedForms.currentPage}
           onPageChange={handleCustomizedPageChange}
+          onPerPageChange={handleCustomizedPerPageChange}
           onSort={handleCustomizedSort}
           onEdit={handleCustomizedEdit}
           onDelete={handleCustomizedDelete}
@@ -383,6 +409,7 @@ const SponsorFormsTab = ({
           totalRows={managedForms.totalCount}
           currentPage={managedForms.currentPage}
           onPageChange={handleManagedPageChange}
+          onPerPageChange={handleManagedPerPageChange}
           onSort={handleManagedSort}
         />
       </div>


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b8bczw1

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-page pagination controls to form templates and sponsor forms interfaces. Users can now customize how many items appear per page. When changing the page size, the view resets to the first page while preserving all active search filters, sorting preferences, and archive visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->