### PR TITLE
fix: add sponsor to dependency array on forms and pages tabs

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
@@ -60,7 +60,7 @@ const SponsorFormsTab = ({
   useEffect(() => {
     getSponsorManagedForms();
     getSponsorCustomizedForms();
-  }, []);
+  }, [sponsor?.id]);
 
   const handleManagedPageChange = (page) => {
     const { perPage, order, orderDir } = managedForms;
@@ -157,7 +157,8 @@ const SponsorFormsTab = ({
     );
   };
 
-  const handleSaveFormFromTemplate = (entity) => saveSponsorManagedForm(entity).then(() => {
+  const handleSaveFormFromTemplate = (entity) =>
+    saveSponsorManagedForm(entity).then(() => {
       const { perPage, order, orderDir } = managedForms;
       getSponsorManagedForms(
         term,

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-media-upload-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-media-upload-tab/index.js
@@ -32,6 +32,7 @@ import UploadDialog from "../../../../../components/upload-dialog";
 import showConfirmDialog from "../../../../../components/mui/showConfirmDialog";
 
 const SponsorMediaUploadTab = ({
+  sponsor,
   sponsorRequests,
   generalRequests,
   getSponsorMURequests,
@@ -44,7 +45,7 @@ const SponsorMediaUploadTab = ({
   useEffect(() => {
     getSponsorMURequests();
     getGeneralMURequests();
-  }, []);
+  }, [sponsor?.id]);
 
   const handleSponsorPageChange = (page) => {
     const { perPage, order, orderDir } = sponsorRequests;
@@ -271,8 +272,9 @@ const SponsorMediaUploadTab = ({
   );
 };
 
-const mapStateToProps = ({ sponsorPageMUListState }) => ({
-  ...sponsorPageMUListState
+const mapStateToProps = ({ sponsorPageMUListState, currentSponsorState }) => ({
+  ...sponsorPageMUListState,
+  sponsor: currentSponsorState.entity
 });
 
 export default connect(mapStateToProps, {

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
@@ -68,7 +68,7 @@ const SponsorPagesTab = ({
   useEffect(() => {
     getSponsorManagedPages();
     getSponsorCustomizedPages();
-  }, []);
+  }, [sponsor?.id]);
 
   const handleManagedPageChange = (page) => {
     const { perPage, order, orderDir } = managedPages;

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/index.js
@@ -32,6 +32,7 @@ import {
 } from "../../../../../utils/constants";
 
 const SponsorPurchasesTab = ({
+  sponsor,
   purchases,
   term,
   order,
@@ -43,7 +44,7 @@ const SponsorPurchasesTab = ({
 }) => {
   useEffect(() => {
     getSponsorPurchases();
-  }, []);
+  }, [sponsor?.id]);
 
   const handlePageChange = (page) => {
     getSponsorPurchases(term, page, perPage, order, orderDir);
@@ -195,8 +196,12 @@ const SponsorPurchasesTab = ({
   );
 };
 
-const mapStateToProps = ({ sponsorPagePurchaseListState }) => ({
-  ...sponsorPagePurchaseListState
+const mapStateToProps = ({
+  sponsorPagePurchaseListState,
+  currentSponsorState
+}) => ({
+  ...sponsorPagePurchaseListState,
+  sponsor: currentSponsorState.entity
 });
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b8xbctk

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sponsor forms and pages now refresh correctly when switching sponsors, ensuring you see the right data for the selected sponsor.
  * Sponsor media uploads and purchase lists now also refresh reliably when changing sponsors.
  * General improvements to data loading when the active sponsor changes for more consistent, up-to-date views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->