### PR TITLE
fix: sponsor settings wire transfer email field alignment

### DIFF
--- a/src/components/forms/sponsor-settings-form/index.js
+++ b/src/components/forms/sponsor-settings-form/index.js
@@ -149,6 +149,7 @@ const SponsorSettingsForm = ({ settings, onSubmit, summitTZ }) => {
                 "sponsor_settings.wire_transfer_notification_email"
               )}
               fullWidth
+              margin="none"
             />
           </Grid2>
           <Grid2 size={12}>


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b8vhmna
<img width="1109" height="920" alt="image" src="https://github.com/user-attachments/assets/779b534d-c6d5-46f6-a409-0fe0d4018571" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined form spacing in sponsor settings for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->