### PR TITLE
fix: empty string as term on sponsor badge scan list

### DIFF
--- a/src/pages/sponsors/badge-scans-list-page.js
+++ b/src/pages/sponsors/badge-scans-list-page.js
@@ -46,16 +46,16 @@ const BadgeScansListPage = ({
   }, []);
 
   const handlePageChange = (page) => {
-    props.getBadgeScans(sponsorId, _, page, perPage, order, orderDir);
+    props.getBadgeScans(sponsorId, "", page, perPage, order, orderDir);
   };
 
   const handleSort = (index, key, dir) => {
-    props.getBadgeScans(sponsorId, _, currentPage, perPage, key, dir);
+    props.getBadgeScans(sponsorId, "", currentPage, perPage, key, dir);
   };
 
   const handleSponsorChange = (ev) => {
     const { value } = ev.target;
-    props.getBadgeScans(value.id, _, currentPage, perPage, order, orderDir);
+    props.getBadgeScans(value.id, "", currentPage, perPage, order, orderDir);
   };
 
   const handleExport = (ev) => {

--- a/src/pages/sponsors/badge-scans-list-page.js
+++ b/src/pages/sponsors/badge-scans-list-page.js
@@ -11,7 +11,7 @@
  * limitations under the License.
  * */
 
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import T from "i18n-react/dist/i18n-react";
 import {
@@ -45,6 +45,8 @@ const BadgeScansListPage = ({
     }
   }, []);
 
+  const [currentSponsor, setCurrentSponsor] = useState(false);
+
   const handlePageChange = (page) => {
     props.getBadgeScans(sponsorId, "", page, perPage, order, orderDir);
   };
@@ -55,13 +57,13 @@ const BadgeScansListPage = ({
 
   const handleSponsorChange = (ev) => {
     const { value } = ev.target;
+    setCurrentSponsor(value);
     props.getBadgeScans(value.id, "", currentPage, perPage, order, orderDir);
   };
 
   const handleExport = (ev) => {
     ev.preventDefault();
-    const sponsor = allSponsors.find((s) => s.id === sponsorId);
-    props.exportBadgeScans(sponsor, order, orderDir);
+    props.exportBadgeScans(currentSponsor, order, orderDir);
   };
 
   const handleEditBadgeScan = (id) => {
@@ -122,8 +124,6 @@ const BadgeScansListPage = ({
 
   if (!currentSummit.id) return <div />;
 
-  // console.log(badgeScans, table_options, columns)
-
   return (
     <div className="container">
       <h3>
@@ -142,7 +142,7 @@ const BadgeScansListPage = ({
           <div className="col-md-6 pull-right">
             <SponsorInput
               id="sponsor"
-              value={sponsorId}
+              value={currentSponsor}
               onChange={handleSponsorChange}
               summitId={currentSummit?.id}
               placeholder={T.translate(


### PR DESCRIPTION
ref: 
* https://app.clickup.com/t/86b9hbpyz
* https://app.clickup.com/t/86b9j6c0d
* https://app.clickup.com/t/86b9j6qwp

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed badge scans list pagination and sorting so navigating pages or reordering correctly refreshes results.
  * Sponsor selector now reflects the chosen sponsor and is consistently used when switching sponsors and exporting badge scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->