### PR TITLE
fix: add validation on sponsor extra questions when they allow values

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -114,7 +114,8 @@
     "time": "Wrong time format.",
     "wrong_format": "Wrong format.",
     "add_on_required": "Select at least one add-on",
-    "additional_items": "Unable to save due to missing required additional info — click the ⚙ icon to review"
+    "additional_items": "Unable to save due to missing required additional info — click the ⚙ icon to review",
+    "extra_question_value": "This question type requires at least one value."
   },
   "price_tiers": {
     "early_bird_rate": "Early Bird Rate",

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-badge-scans/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-badge-scans/index.js
@@ -20,6 +20,7 @@ import AddIcon from "@mui/icons-material/Add";
 import DownloadIcon from "@mui/icons-material/Download";
 import MuiTable from "openstack-uicore-foundation/lib/components/mui/table";
 import {
+  getSponsor,
   getBadgeScans,
   exportBadgeScans,
   getBadgeScan,
@@ -42,6 +43,7 @@ const SponsorBadgeScans = ({
   orderDir,
   currentPage,
   perPage,
+  getSponsor,
   getBadgeScans,
   exportBadgeScans,
   getBadgeScan,
@@ -50,8 +52,10 @@ const SponsorBadgeScans = ({
   currentBadgeScan
 }) => {
   useEffect(() => {
-    if (sponsor?.id) getBadgeScans(sponsor.id);
-  }, [sponsor]);
+    if (sponsor?.id) {
+      getSponsor(sponsor.id).then(() => getBadgeScans(sponsor.id));
+    }
+  }, [sponsor.id]);
 
   const memberObj = new Member(member);
   const isAdmin = memberObj.hasAccess("admin-sponsors");
@@ -287,6 +291,7 @@ const mapStateToProps = ({
 });
 
 export default connect(mapStateToProps, {
+  getSponsor,
   getBadgeScans,
   exportBadgeScans,
   getBadgeScan,

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-general-form/add-extra-question-popup.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-general-form/add-extra-question-popup.js
@@ -34,6 +34,7 @@ import {
   deleteSponsorExtraQuestionValue,
   updateSponsorExtraQuestionValueOrder
 } from "../../../../../actions/sponsor-actions";
+import { ExtraQuestionsTypeAllowSubQuestion } from "../../../../../utils/constants";
 
 const AddSponsorExtraQuestionPopup = ({
   entity: extraQuestion,
@@ -67,15 +68,23 @@ const AddSponsorExtraQuestionPopup = ({
       mandatory: yup.boolean(),
       placeholder: yup.string(),
       max_selected_values: yup.number(),
-      values: yup.array().of(
-        yup.object().shape({
-          value: yup.string().required(T.translate("validation.required")),
-          label: yup.string().required(T.translate("validation.required")),
-          is_default: yup.boolean(),
-          order: yup.number(),
-          _shouldSave: yup.boolean()
+      values: yup
+        .array()
+        .when("type", {
+          is: (type) => ExtraQuestionsTypeAllowSubQuestion.includes(type),
+          then: (schema) =>
+            schema.min(1, T.translate("validation.extra_question_value")),
+          otherwise: (schema) => schema
         })
-      )
+        .of(
+          yup.object().shape({
+            value: yup.string().required(T.translate("validation.required")),
+            label: yup.string().required(T.translate("validation.required")),
+            is_default: yup.boolean(),
+            order: yup.number(),
+            _shouldSave: yup.boolean()
+          })
+        )
     }),
     onSubmit: (values) => {
       const valuesToSave = values.values
@@ -183,7 +192,7 @@ const AddSponsorExtraQuestionPopup = ({
   };
 
   const areExtraQuestionsIncomplete = () => {
-    if (formik.errors.values) return true;
+    if (Array.isArray(formik.errors.values)) return true;
     return formik.values.values.some(
       (eq) => eq.name?.trim() === "" || eq.label?.trim() === ""
     );
@@ -484,6 +493,16 @@ const AddSponsorExtraQuestionPopup = ({
                       >
                         {T.translate("edit_sponsor.add_value")}
                       </Button>
+                      {typeof formik.errors.values === "string" &&
+                        formik.submitCount > 0 && (
+                          <Typography
+                            color="error"
+                            fontSize="1.2rem"
+                            sx={{ mt: 0.5, ml: 2 }}
+                          >
+                            {formik.errors.values}
+                          </Typography>
+                        )}
                     </>
                   )}
                 </FieldArray>


### PR DESCRIPTION
* Updates extra questions from sponsor on badge scan tab

ref: https://app.clickup.com/t/86b9jxz9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced minimum value requirement for certain question types in forms.
  * Improved display of validation errors for incomplete form submissions.
  * Adjusted data load sequencing to ensure sponsor details load before badge scans.

* **Chores**
  * Updated and added validation message text for error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->