### PR TITLE
fix: adjust breadcrumb to purchase order with ticket list opened

### DIFF
--- a/src/components/forms/purchase-order-form.js
+++ b/src/components/forms/purchase-order-form.js
@@ -23,6 +23,7 @@ import {
 } from "openstack-uicore-foundation/lib/components";
 import { epochToMoment } from "openstack-uicore-foundation/lib/utils/methods";
 import { Pagination } from "react-bootstrap";
+import URI from "urijs";
 import OwnerInput from "../inputs/owner-input";
 import {
   hasErrors,
@@ -37,11 +38,12 @@ import CopyClipboard from "../buttons/copy-clipboard";
 class PurchaseOrderForm extends React.Component {
   constructor(props) {
     super(props);
+    const query = URI.parseQuery(location.search);
 
     this.state = {
       entity: { ...props.entity },
       errors: props.errors,
-      showSection: "billing",
+      showSection: query?.section === "tickets" ? "tickets" : "billing",
       addTicketTypeId: null,
       addTicketQty: 0,
       addPromoCode: null

--- a/src/components/forms/purchase-order-form.js
+++ b/src/components/forms/purchase-order-form.js
@@ -38,7 +38,7 @@ import CopyClipboard from "../buttons/copy-clipboard";
 class PurchaseOrderForm extends React.Component {
   constructor(props) {
     super(props);
-    const query = URI.parseQuery(location.search);
+    const query = URI.parseQuery(props.location?.search || "");
 
     this.state = {
       entity: { ...props.entity },

--- a/src/layouts/purchase-order-id-layout.js
+++ b/src/layouts/purchase-order-id-layout.js
@@ -62,7 +62,8 @@ const PurchaseOrderIdLayout = ({ currentPurchaseOrder, match, ...props }) => {
               <Breadcrumb
                 data={{
                   title: T.translate("purchase_order_list.tickets"),
-                  pathname: match.url
+                  pathname: match.url,
+                  search: "?section=tickets"
                 }}
               />
               <EditTicketPage {...props} />

--- a/src/pages/orders/edit-purchase-order-page.js
+++ b/src/pages/orders/edit-purchase-order-page.js
@@ -32,6 +32,7 @@ const EditPurchaseOrderPage = ({
   errors,
   currentSummit,
   history,
+  location,
   ticketsCurrentPage,
   ticketsTotal,
   ticketsLastPage,
@@ -93,6 +94,7 @@ const EditPurchaseOrderPage = ({
 
       <PurchaseOrderForm
         history={history}
+        location={location}
         currentSummit={currentSummit}
         entity={entity}
         errors={errors}


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9maebc

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchase order forms now support direct navigation to the Tickets section via URL parameters, enabling shareable links that open the form to Tickets.
  * Page navigation preserves the Tickets section in breadcrumbs so users stay in the intended section when navigating.
  * The edit page forwards location data to the form so URL-driven section selection works consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->