### PR TITLE
fix: display amount column based on raw_amount - discount values

### DIFF
--- a/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
@@ -64,7 +64,7 @@ const sponsorPagePurchaseListReducer = (state = DEFAULT_STATE, action) => {
       const purchases = payload.response.data.map((a) => ({
         ...a,
         order: a.order_number,
-        amount: `$${amountFromCents(a.raw_amount)}`,
+        amount: `$${amountFromCents(a.raw_amount - a.discount_amount)}`,
         purchased: moment(a.created * MILLISECONDS_TO_SECONDS).format(
           "YYYY/MM/DD HH:mm a"
         )


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9m8dpt

<img width="1179" height="978" alt="image" src="https://github.com/user-attachments/assets/655f4c50-f950-49a8-b329-58f6316b87d2" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect display of sponsor purchase amounts when discounts are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->