### PR TITLE
fix: add allowed extensions props on formik input component

### DIFF
--- a/src/pages/sponsors-global/page-templates/page-template-popup/modules/page-template-document-download-module.js
+++ b/src/pages/sponsors-global/page-templates/page-template-popup/modules/page-template-document-download-module.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import T from "i18n-react/dist/i18n-react";
 import { useField } from "formik";
 import { Divider, Grid2, InputLabel } from "@mui/material";
-import { MuiFormikUpload } from "openstack-uicore-foundation/lib/components";
+import MuiFormikUpload from "openstack-uicore-foundation/lib/components/mui/formik-inputs/upload";
 import MuiFormikTextField from "../../../../../components/mui/formik-inputs/mui-formik-textfield";
 import {
   ALLOWED_INVENTORY_IMAGE_FORMATS,

--- a/src/pages/sponsors-global/page-templates/page-template-popup/modules/page-template-document-download-module.js
+++ b/src/pages/sponsors-global/page-templates/page-template-popup/modules/page-template-document-download-module.js
@@ -5,7 +5,10 @@ import { useField } from "formik";
 import { Divider, Grid2, InputLabel } from "@mui/material";
 import { MuiFormikUpload } from "openstack-uicore-foundation/lib/components";
 import MuiFormikTextField from "../../../../../components/mui/formik-inputs/mui-formik-textfield";
-import { PAGE_MODULES_DOWNLOAD } from "../../../../../utils/constants";
+import {
+  ALLOWED_INVENTORY_IMAGE_FORMATS,
+  PAGE_MODULES_DOWNLOAD
+} from "../../../../../utils/constants";
 import MuiFormikRadioGroup from "../../../../../components/mui/formik-inputs/mui-formik-radio-group";
 
 const DocumentDownloadModule = ({ baseName, index }) => {
@@ -79,6 +82,7 @@ const DocumentDownloadModule = ({ baseName, index }) => {
             id={`document-module-upload-${index}`}
             name={buildFieldName("file")}
             maxFiles={1}
+            allowedExtensions={["pdf", ...ALLOWED_INVENTORY_IMAGE_FORMATS]}
           />
         </Grid2>
       )}

--- a/src/pages/sponsors-global/page-templates/page-template-popup/page-template-module-form.test.js
+++ b/src/pages/sponsors-global/page-templates/page-template-popup/page-template-module-form.test.js
@@ -30,6 +30,14 @@ jest.mock(
 );
 
 jest.mock(
+  "openstack-uicore-foundation/lib/components/mui/formik-inputs/upload",
+  () =>
+    function MockMuiFormikUpload({ name }) {
+      return <div data-testid={`upload-${name}`}>Upload</div>;
+    }
+);
+
+jest.mock(
   "../../../../components/mui/formik-inputs/mui-formik-textfield",
   () =>
     function MockMuiFormikTextField({ name }) {


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9c38wj

<img width="930" height="277" alt="image" src="https://github.com/user-attachments/assets/b600a9c6-ec59-460d-a9ab-1aa19bab8e92" />

<img width="941" height="196" alt="image" src="https://github.com/user-attachments/assets/8f92ffc4-7c71-43f1-a05b-533cbd8089b3" />


Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File upload now supports configurable allowed file extensions.
  * Document upload accepts PDFs in addition to supported image formats.

* **Tests**
  * Upload-related tests updated to reflect the refactored upload component import.

* **Chores**
  * Internal dependency for the upload component adjusted (maintenance update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->