### PR TITLE
feat: migrate track chair list and edit to mui components

### DIFF
--- a/src/actions/track-chair-actions.js
+++ b/src/actions/track-chair-actions.js
@@ -35,6 +35,7 @@ import {
   DEFAULT_PER_PAGE,
   DOUBLE_PER_PAGE
 } from "../utils/constants";
+import { snackbarErrorHandler } from "./base-actions";
 
 URI.escapeQuerySpace = false;
 
@@ -95,7 +96,7 @@ export const getTrackChairs =
       expand: "member,categories",
       relations: "member.none,categories.none",
       fields:
-        "id,categories.id,categories.name,member.first_name,member.last_name,member.email"
+        "id,categories.id,categories.name,member.first_name,member.last_name,member.email,member.id"
     };
 
     if (filter.length > 0) {
@@ -125,9 +126,9 @@ export const getTrackChairs =
       createAction(REQUEST_TRACK_CHAIRS),
       createAction(RECEIVE_TRACK_CHAIRS),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs`,
-      authErrorHandler,
-      { trackId, term, order, orderDir }
-    )(params)(dispatch).then(() => {
+      snackbarErrorHandler,
+      { trackId, term, order, orderDir, perPage }
+    )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
   };
@@ -150,7 +151,7 @@ export const addTrackChair =
       createAction(TRACK_CHAIR_ADDED),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs`,
       { member_id: member.id, categories: trackIds },
-      authErrorHandler
+      snackbarErrorHandler
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });
@@ -175,7 +176,7 @@ export const saveTrackChair =
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs/${trackChairId}`,
       { categories: trackIds },
       authErrorHandler
-    )(params)(dispatch).then(() => {
+    )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
   };
@@ -195,8 +196,8 @@ export const deleteTrackChair =
       createAction(TRACK_CHAIR_DELETED)({ trackChairId }),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs/${trackChairId}`,
       null,
-      authErrorHandler
-    )(params)(dispatch).then(() => {
+      snackbarErrorHandler
+    )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
   };

--- a/src/actions/track-chair-actions.js
+++ b/src/actions/track-chair-actions.js
@@ -23,7 +23,7 @@ import {
   stopLoading
 } from "openstack-uicore-foundation/lib/utils/actions";
 import URI from "urijs";
-import debounce from "lodash/debounce"
+import debounce from "lodash/debounce";
 import {
   fetchErrorHandler,
   fetchResponseHandler,
@@ -175,7 +175,7 @@ export const saveTrackChair =
       createAction(TRACK_CHAIR_UPDATED),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs/${trackChairId}`,
       { categories: trackIds },
-      authErrorHandler
+      snackbarErrorHandler
     )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });

--- a/src/actions/track-chair-actions.js
+++ b/src/actions/track-chair-actions.js
@@ -127,7 +127,7 @@ export const getTrackChairs =
       createAction(RECEIVE_TRACK_CHAIRS),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs`,
       snackbarErrorHandler,
-      { trackId, term, order, orderDir, perPage }
+      { trackId, term, order, orderDir, page, perPage }
     )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
@@ -152,7 +152,7 @@ export const addTrackChair =
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-chairs`,
       { member_id: member.id, categories: trackIds },
       snackbarErrorHandler
-    )(params)(dispatch).then(() => {
+    )(params)(dispatch).finally(() => {
       dispatch(stopLoading());
     });
   };

--- a/src/components/mui/__tests__/mui-formik-async-select.test.js
+++ b/src/components/mui/__tests__/mui-formik-async-select.test.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Formik, useFormikContext } from "formik";
+import "@testing-library/jest-dom";
+import MuiFormikAsyncAutocomplete from "../formik-inputs/mui-formik-async-select";
+
+jest.mock("@mui/material", () => {
+  const actual = jest.requireActual("@mui/material");
+  return {
+    ...actual,
+    Autocomplete: ({ onChange, options }) => (
+      <button
+        type="button"
+        data-testid="select-option"
+        onClick={() => onChange({}, options[0])}
+      >
+        select
+      </button>
+    )
+  };
+});
+
+const FieldValue = () => {
+  const { values } = useFormikContext();
+  return <div data-testid="field-value">{JSON.stringify(values.member)}</div>;
+};
+
+const renderWithFormik = (props) =>
+  render(
+    <Formik initialValues={{ member: null }} onSubmit={jest.fn()}>
+      <>
+        <MuiFormikAsyncAutocomplete name="member" {...props} />
+        <FieldValue />
+      </>
+    </Formik>
+  );
+
+describe("MuiFormikAsyncAutocomplete", () => {
+  test("keeps its internal onChange in control of the Formik field even when a consumer passes its own onChange prop", async () => {
+    const queryFunction = (input, callback) =>
+      callback([{ id: 1, name: "Jane Doe" }]);
+    const consumerOnChange = jest.fn();
+
+    await act(async () => {
+      renderWithFormik({ queryFunction, onChange: consumerOnChange });
+    });
+
+    await userEvent.click(screen.getByTestId("select-option"));
+
+    expect(consumerOnChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("field-value")).toHaveTextContent(
+      JSON.stringify({ value: "1", label: "Jane Doe" })
+    );
+  });
+});

--- a/src/components/mui/formik-inputs/mui-formik-async-select.js
+++ b/src/components/mui/formik-inputs/mui-formik-async-select.js
@@ -91,6 +91,7 @@ const MuiFormikAsyncAutocomplete = ({
 
   return (
     <Autocomplete
+      {...rest}
       options={options}
       value={value}
       onChange={handleChange}
@@ -143,7 +144,6 @@ const MuiFormikAsyncAutocomplete = ({
           {option.label}
         </li>
       )}
-      {...rest}
     />
   );
 };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -3581,7 +3581,7 @@
     "no_items": "No items found for this search criteria.",
     "name": "Name",
     "track": "Track",
-    "delete_warning": "Are you sure you want to remove track chair ",
+    "delete_warning": "Are you sure you want to remove track chair for",
     "saved": "Track chair assigned successfully.",
     "placeholders": {
       "search": "Search track chairs by name",

--- a/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
+++ b/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
@@ -1,0 +1,229 @@
+import React from "react";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithRedux } from "utils/test-utils";
+import {
+  saveTrackChair,
+  addTrackChair,
+  deleteTrackChair
+} from "../../../actions/track-chair-actions";
+import TrackChairListPage from "../track-chair-list-page";
+
+jest.mock("../../../actions/track-chair-actions", () => ({
+  getTrackChairs: jest.fn(() => () => Promise.resolve()),
+  deleteTrackChair: jest.fn(() => () => Promise.resolve()),
+  saveTrackChair: jest.fn(() => () => Promise.resolve()),
+  addTrackChair: jest.fn(() => () => Promise.resolve()),
+  exportTrackChairs: jest.fn(() => () => Promise.resolve())
+}));
+
+jest.mock(
+  "openstack-uicore-foundation/lib/components/mui/table",
+  () =>
+    function MockMuiTable({ data, onEdit, onDelete }) {
+      return (
+        <div>
+          {data.map((item) => (
+            <div key={item.id}>
+              <button
+                data-testid={`edit-${item.id}`}
+                onClick={() => onEdit(item)}
+              >
+                edit-{item.id}
+              </button>
+              <button
+                data-testid={`delete-${item.id}`}
+                onClick={() => onDelete(item.id)}
+              >
+                delete-{item.id}
+              </button>
+            </div>
+          ))}
+        </div>
+      );
+    }
+);
+
+jest.mock(
+  "openstack-uicore-foundation/lib/components/mui/search-input",
+  () => () => null
+);
+
+// Capture the dialog's props so tests can call onSave/onClose with specific values
+let capturedDialogProps = null;
+jest.mock("../components/track-chair-dialog", () => ({
+  __esModule: true,
+  default: (props) => {
+    capturedDialogProps = props;
+    return <div data-testid="track-chair-dialog" />;
+  }
+}));
+
+const mockTracks = [
+  { id: 1, name: "Track A", chair_visible: true },
+  { id: 2, name: "Track B", chair_visible: true }
+];
+
+const mockTrackChair = {
+  id: 10,
+  name: "Jane Doe (jane@example.com)",
+  member: {
+    id: 42,
+    first_name: "Jane",
+    last_name: "Doe",
+    email: "jane@example.com"
+  },
+  categories: [{ id: 1, name: "Track A" }],
+  trackIds: [1],
+  trackNames: "Track A"
+};
+
+const initialState = {
+  currentSummitState: {
+    currentSummit: { id: 1, name: "Test Summit", tracks: mockTracks }
+  },
+  trackChairListState: {
+    trackChairs: [],
+    trackId: null,
+    term: "",
+    order: "id",
+    orderDir: 1,
+    currentPage: 1,
+    lastPage: 1,
+    perPage: 10,
+    totalTrackChairs: 0
+  }
+};
+
+describe("TrackChairListPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedDialogProps = null;
+  });
+
+  const renderPage = (stateOverrides = {}) =>
+    renderWithRedux(<TrackChairListPage history={{ push: jest.fn() }} />, {
+      initialState: {
+        ...initialState,
+        trackChairListState: {
+          ...initialState.trackChairListState,
+          ...stateOverrides
+        }
+      }
+    });
+
+  describe("dialog visibility", () => {
+    it("shows after clicking Add and closes when onClose is called", async () => {
+      renderPage();
+      expect(
+        screen.queryByTestId("track-chair-dialog")
+      ).not.toBeInTheDocument();
+
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: /add/i }));
+      });
+      expect(screen.getByTestId("track-chair-dialog")).toBeInTheDocument();
+
+      await act(async () => {
+        capturedDialogProps.onClose();
+      });
+      expect(
+        screen.queryByTestId("track-chair-dialog")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("handleEdit", () => {
+    it("passes the correct entity shape to the dialog", async () => {
+      renderPage({ trackChairs: [mockTrackChair] });
+
+      await act(async () => {
+        await userEvent.click(screen.getByTestId(`edit-${mockTrackChair.id}`));
+      });
+
+      expect(capturedDialogProps.entity).toEqual({
+        id: mockTrackChair.id,
+        member: mockTrackChair.member,
+        originalMemberId: mockTrackChair.member.id,
+        trackIds: [1] // mapped from categories
+      });
+    });
+  });
+
+  describe("handleDelete", () => {
+    it("calls deleteTrackChair with the row id", async () => {
+      renderPage({ trackChairs: [mockTrackChair] });
+
+      await act(async () => {
+        await userEvent.click(
+          screen.getByTestId(`delete-${mockTrackChair.id}`)
+        );
+      });
+
+      expect(deleteTrackChair).toHaveBeenCalledWith(mockTrackChair.id);
+    });
+  });
+
+  describe("handleSave", () => {
+    it("calls addTrackChair when saving a new chair (no id)", async () => {
+      renderPage();
+
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: /add/i }));
+      });
+
+      await act(async () => {
+        await capturedDialogProps.onSave({
+          id: 0,
+          member: { value: 99, label: "New Member" },
+          trackIds: [1]
+        });
+      });
+
+      expect(addTrackChair).toHaveBeenCalledWith({ id: 99 }, [1]);
+      expect(saveTrackChair).not.toHaveBeenCalled();
+    });
+
+    it("calls saveTrackChair when only tracks change on an existing chair", async () => {
+      renderPage({ trackChairs: [mockTrackChair] });
+
+      await act(async () => {
+        await userEvent.click(screen.getByTestId(`edit-${mockTrackChair.id}`));
+      });
+
+      // Same member (value: 42 === originalMemberId: 42), different tracks
+      await act(async () => {
+        await capturedDialogProps.onSave({
+          id: mockTrackChair.id,
+          member: { value: 42 },
+          trackIds: [1, 2]
+        });
+      });
+
+      expect(saveTrackChair).toHaveBeenCalledWith(mockTrackChair.id, [1, 2]);
+      expect(addTrackChair).not.toHaveBeenCalled();
+    });
+
+    it("closes the dialog after save succeeds", async () => {
+      renderPage();
+
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: /add/i }));
+      });
+
+      expect(screen.getByTestId("track-chair-dialog")).toBeInTheDocument();
+
+      await act(async () => {
+        await capturedDialogProps.onSave({
+          id: 0,
+          member: { value: 99 },
+          trackIds: [1]
+        });
+      });
+
+      expect(
+        screen.queryByTestId("track-chair-dialog")
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
+++ b/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
@@ -203,27 +203,5 @@ describe("TrackChairListPage", () => {
       expect(saveTrackChair).toHaveBeenCalledWith(mockTrackChair.id, [1, 2]);
       expect(addTrackChair).not.toHaveBeenCalled();
     });
-
-    it("closes the dialog after save succeeds", async () => {
-      renderPage();
-
-      await act(async () => {
-        await userEvent.click(screen.getByRole("button", { name: /add/i }));
-      });
-
-      expect(screen.getByTestId("track-chair-dialog")).toBeInTheDocument();
-
-      await act(async () => {
-        await capturedDialogProps.onSave({
-          id: 0,
-          member: { value: 99 },
-          trackIds: [1]
-        });
-      });
-
-      expect(
-        screen.queryByTestId("track-chair-dialog")
-      ).not.toBeInTheDocument();
-    });
   });
 });

--- a/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
+++ b/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
@@ -3,6 +3,7 @@ import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithRedux } from "utils/test-utils";
 import {
+  getTrackChairs,
   saveTrackChair,
   addTrackChair,
   deleteTrackChair
@@ -144,7 +145,6 @@ describe("TrackChairListPage", () => {
       expect(capturedDialogProps.entity).toEqual({
         id: mockTrackChair.id,
         member: mockTrackChair.member,
-        originalMemberId: mockTrackChair.member.id,
         trackIds: [1] // mapped from categories
       });
     });
@@ -182,16 +182,17 @@ describe("TrackChairListPage", () => {
 
       expect(addTrackChair).toHaveBeenCalledWith({ id: 99 }, [1]);
       expect(saveTrackChair).not.toHaveBeenCalled();
+      // adding resets back to the first page
+      expect(getTrackChairs).toHaveBeenLastCalledWith(null, "", 1, 10, "id", 1);
     });
 
-    it("calls saveTrackChair when only tracks change on an existing chair", async () => {
-      renderPage({ trackChairs: [mockTrackChair] });
+    it("calls saveTrackChair when editing an existing chair, keeping the current page", async () => {
+      renderPage({ trackChairs: [mockTrackChair], currentPage: 3 });
 
       await act(async () => {
         await userEvent.click(screen.getByTestId(`edit-${mockTrackChair.id}`));
       });
 
-      // Same member (value: 42 === originalMemberId: 42), different tracks
       await act(async () => {
         await capturedDialogProps.onSave({
           id: mockTrackChair.id,
@@ -202,6 +203,32 @@ describe("TrackChairListPage", () => {
 
       expect(saveTrackChair).toHaveBeenCalledWith(mockTrackChair.id, [1, 2]);
       expect(addTrackChair).not.toHaveBeenCalled();
+      // editing stays on the current page instead of resetting to the first one
+      expect(getTrackChairs).toHaveBeenLastCalledWith(null, "", 3, 10, "id", 1);
+    });
+
+    it("resolves (and lets the dialog close) even if the post-save reload fails", async () => {
+      renderPage();
+
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: /add/i }));
+      });
+
+      // only the reload triggered by save should reject, not the initial mount load
+      getTrackChairs.mockImplementationOnce(
+        () => () => Promise.reject(new Error("network blip"))
+      );
+
+      let saveResult;
+      await act(async () => {
+        saveResult = capturedDialogProps.onSave({
+          id: 0,
+          member: { value: 99, label: "New Member" },
+          trackIds: [1]
+        });
+      });
+
+      await expect(saveResult).resolves.toBeUndefined();
     });
   });
 });

--- a/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
+++ b/src/pages/track_chairs/__tests__/track-chair-list-page.test.js
@@ -162,6 +162,31 @@ describe("TrackChairListPage", () => {
 
       expect(deleteTrackChair).toHaveBeenCalledWith(mockTrackChair.id);
     });
+
+    it("reloads the list on the first page after a successful delete", async () => {
+      renderPage({
+        trackChairs: [mockTrackChair],
+        currentPage: 3,
+        term: "abc",
+        order: "trackName",
+        orderDir: -1
+      });
+
+      await act(async () => {
+        await userEvent.click(
+          screen.getByTestId(`delete-${mockTrackChair.id}`)
+        );
+      });
+
+      expect(getTrackChairs).toHaveBeenLastCalledWith(
+        null,
+        "abc",
+        1,
+        10,
+        "trackName",
+        -1
+      );
+    });
   });
 
   describe("handleSave", () => {

--- a/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
+++ b/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
@@ -110,7 +110,7 @@ describe("TrackChairDialog", () => {
   });
 
   describe("valid submit", () => {
-    it("calls onSave with { id, member, trackIds } on valid submit", async () => {
+    it("calls onSave with { id, member, trackIds } and then onClose on valid submit", async () => {
       renderDialog();
       await selectMember();
       await selectTrack("Track A");
@@ -120,6 +120,7 @@ describe("TrackChairDialog", () => {
         member: { value: 42, label: "John Doe (john@example.com)" },
         trackIds: [1]
       });
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it("pre-fills entity values and submits member as { value, label }", async () => {

--- a/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
+++ b/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
@@ -1,0 +1,226 @@
+import React from "react";
+import { act, screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TrackChairDialog from "../track-chair-dialog";
+
+jest.mock("../../../../hooks/useScrollToError", () => jest.fn());
+
+jest.mock("openstack-uicore-foundation/lib/utils/query-actions", () => ({
+  queryMembers: jest.fn()
+}));
+
+jest.mock(
+  "../../../../components/mui/formik-inputs/mui-formik-async-select",
+  () =>
+    function MockMuiFormikAsyncSelect({ name, disabled }) {
+      const { useFormikContext } = require("formik");
+      const { setFieldValue } = useFormikContext();
+      return (
+        <button
+          type="button"
+          data-testid={`async-select-${name}`}
+          disabled={disabled}
+          onClick={() =>
+            setFieldValue(name, {
+              value: 42,
+              label: "John Doe (john@example.com)"
+            })
+          }
+        >
+          select-member
+        </button>
+      );
+    }
+);
+
+const mockTracks = [
+  { id: 1, name: "Track A" },
+  { id: 2, name: "Track B" }
+];
+
+describe("TrackChairDialog", () => {
+  const onSave = jest.fn();
+  const onClose = jest.fn();
+
+  const defaultProps = {
+    entity: {},
+    tracks: mockTracks,
+    onSave,
+    onClose
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onSave.mockResolvedValue();
+  });
+
+  const renderDialog = (props = {}) =>
+    render(<TrackChairDialog {...defaultProps} {...props} />);
+
+  const selectMember = async () => {
+    await act(async () => {
+      await userEvent.click(screen.getByTestId("async-select-member"));
+    });
+  };
+
+  const selectTrack = async (trackName = "Track A") => {
+    await act(async () => {
+      await userEvent.click(screen.getByRole("combobox"));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByRole("option", { name: trackName }));
+    });
+    // Close the dropdown before interacting with other elements
+    await act(async () => {
+      await userEvent.keyboard("{Escape}");
+    });
+  };
+
+  const clickSave = async () => {
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    });
+  };
+
+  const setupPendingSave = () => {
+    let resolveSave;
+    let rejectSave;
+    const pendingPromise = new Promise((resolve, reject) => {
+      resolveSave = resolve;
+      rejectSave = reject;
+    });
+    onSave.mockReturnValue(pendingPromise);
+    return { resolveSave, rejectSave, pendingPromise };
+  };
+
+  describe("validation", () => {
+    it("blocks submit when member is empty", async () => {
+      renderDialog();
+      await clickSave();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it("blocks submit and shows error when trackIds is empty", async () => {
+      renderDialog();
+      await selectMember();
+      await clickSave();
+      expect(onSave).not.toHaveBeenCalled();
+      expect(screen.getByText("validation.required")).toBeInTheDocument();
+    });
+  });
+
+  describe("valid submit", () => {
+    it("calls onSave with { id, member, trackIds } on valid submit", async () => {
+      renderDialog();
+      await selectMember();
+      await selectTrack("Track A");
+      await clickSave();
+      expect(onSave).toHaveBeenCalledWith({
+        id: 0,
+        member: { value: 42, label: "John Doe (john@example.com)" },
+        trackIds: [1]
+      });
+    });
+
+    it("pre-fills entity values and submits member as { value, label }", async () => {
+      const entity = {
+        id: 5,
+        member: {
+          id: 10,
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "jane@example.com"
+        },
+        originalMemberId: 10,
+        trackIds: [2]
+      };
+      renderDialog({ entity });
+      await clickSave();
+      expect(onSave).toHaveBeenCalledWith({
+        id: 5,
+        member: { value: 10, label: "Jane Doe (jane@example.com)" },
+        trackIds: [2]
+      });
+    });
+
+    it("disables the member field when editing an existing chair", () => {
+      const entity = {
+        id: 5,
+        member: {
+          id: 10,
+          first_name: "Jane",
+          last_name: "Doe",
+          email: "jane@example.com"
+        },
+        trackIds: [1]
+      };
+      renderDialog({ entity });
+      expect(screen.getByTestId("async-select-member")).toBeDisabled();
+    });
+  });
+
+  describe("isSaving behavior", () => {
+    it("disables save and close buttons while saving, re-enables after resolve", async () => {
+      const { resolveSave } = setupPendingSave();
+      renderDialog();
+      await selectMember();
+      await selectTrack();
+      await clickSave();
+
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /close/i })).toBeDisabled();
+
+      await act(async () => {
+        resolveSave();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /close/i })).not.toBeDisabled();
+    });
+
+    it("re-enables buttons after save rejects", async () => {
+      const { rejectSave, pendingPromise } = setupPendingSave();
+      renderDialog();
+      await selectMember();
+      await selectTrack();
+      await clickSave();
+
+      await act(async () => {
+        rejectSave(new Error("save failed"));
+        await pendingPromise.catch(() => {});
+      });
+
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /close/i })).not.toBeDisabled();
+    });
+
+    it("does not call onClose when Escape is pressed during a save", async () => {
+      const { resolveSave } = setupPendingSave();
+      renderDialog();
+      await selectMember();
+      await selectTrack();
+      await clickSave();
+
+      // disableEscapeKeyDown={true} while isSaving — onClose must not fire
+      await act(async () => {
+        await userEvent.keyboard("{Escape}");
+      });
+
+      expect(onClose).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveSave();
+        await Promise.resolve();
+      });
+    });
+
+    it("calls onClose when the close button is clicked and not saving", async () => {
+      renderDialog();
+      await act(async () => {
+        await userEvent.click(screen.getByRole("button", { name: /close/i }));
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
+++ b/src/pages/track_chairs/components/__tests__/track-chair-dialog.test.js
@@ -132,7 +132,6 @@ describe("TrackChairDialog", () => {
           last_name: "Doe",
           email: "jane@example.com"
         },
-        originalMemberId: 10,
         trackIds: [2]
       };
       renderDialog({ entity });

--- a/src/pages/track_chairs/components/track-chair-dialog.js
+++ b/src/pages/track_chairs/components/track-chair-dialog.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright 2024 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * */
+
+import React from "react";
+import PropTypes from "prop-types";
+import T from "i18n-react/dist/i18n-react";
+import { FormikProvider, useFormik } from "formik";
+import * as yup from "yup";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormHelperText,
+  Grid2,
+  IconButton,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
+  Typography
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import ClearIcon from "@mui/icons-material/Clear";
+import { queryMembers } from "openstack-uicore-foundation/lib/utils/query-actions";
+import MuiFormikAsyncAutocomplete from "../../../components/mui/formik-inputs/mui-formik-async-select";
+import useScrollToError from "../../../hooks/useScrollToError";
+
+const formatMemberOption = (m) => ({
+  value: m.id,
+  label: m.email
+    ? `${m.first_name} ${m.last_name} (${m.email})`
+    : `${m.first_name} ${m.last_name} (${m.id})`
+});
+
+const toMemberOption = (member) => {
+  if (!member) return null;
+  return formatMemberOption(member);
+};
+
+const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
+  const formik = useFormik({
+    initialValues: {
+      id: entity?.id ?? 0,
+      member: toMemberOption(entity?.member ?? null),
+      trackIds: entity?.trackIds ?? []
+    },
+    enableReinitialize: true,
+    validationSchema: yup.object().shape({
+      member: yup
+        .object()
+        .nullable()
+        .required(T.translate("validation.required")),
+      trackIds: yup
+        .array()
+        .min(1, T.translate("validation.required"))
+        .required(T.translate("validation.required"))
+    }),
+    onSubmit: (values) => onSave(values)
+  });
+
+  useScrollToError(formik, true);
+
+  const title = entity?.id
+    ? `${T.translate("general.edit")} ${T.translate(
+        "track_chairs.track_chair"
+      )}`
+    : T.translate("track_chairs.add");
+
+  const tracks_ddl = tracks.map((t) => ({ label: t.name, value: t.id }));
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Typography fontSize="1.5rem">{title}</Typography>
+        <IconButton
+          size="small"
+          onClick={onClose}
+          sx={{ mr: 1 }}
+          aria-label="close"
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <Divider />
+      <FormikProvider value={formik}>
+        <Box
+          component="form"
+          onSubmit={formik.handleSubmit}
+          noValidate
+          autoComplete="off"
+        >
+          <DialogContent sx={{ p: 0 }}>
+            <Grid2 container spacing={2} size={12} sx={{ p: 3 }}>
+              <Grid2 size={12}>
+                <InputLabel>
+                  {T.translate("track_chairs.placeholders.select_track_chair")}{" "}
+                  *
+                </InputLabel>
+                <MuiFormikAsyncAutocomplete
+                  name="member"
+                  queryFunction={queryMembers}
+                  formatOption={formatMemberOption}
+                  placeholder={T.translate(
+                    "track_chairs.placeholders.select_track_chair"
+                  )}
+                />
+              </Grid2>
+              <Grid2 size={12}>
+                <InputLabel htmlFor="trackIds">
+                  {T.translate("track_chairs.track")} *
+                </InputLabel>
+                <FormControl
+                  fullWidth
+                  error={
+                    formik.touched.trackIds && Boolean(formik.errors.trackIds)
+                  }
+                >
+                  <Select
+                    id="trackIds"
+                    multiple
+                    value={formik.values.trackIds}
+                    onChange={(ev) =>
+                      formik.setFieldValue("trackIds", ev.target.value)
+                    }
+                    onBlur={() => formik.setFieldTouched("trackIds", true)}
+                    displayEmpty
+                    renderValue={(selected) =>
+                      selected.length === 0 ? (
+                        <span style={{ color: "#aaa" }}>
+                          {T.translate(
+                            "track_chairs.placeholders.select_track"
+                          )}
+                        </span>
+                      ) : (
+                        <Box
+                          sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}
+                        >
+                          {selected.map((id) => {
+                            const track = tracks_ddl.find(
+                              (t) => t.value === id
+                            );
+                            return track ? (
+                              <Chip
+                                key={id}
+                                label={track.label}
+                                size="small"
+                                onDelete={() =>
+                                  formik.setFieldValue(
+                                    "trackIds",
+                                    formik.values.trackIds.filter(
+                                      (v) => v !== id
+                                    )
+                                  )
+                                }
+                                deleteIcon={
+                                  <ClearIcon
+                                    onMouseDown={(e) => e.stopPropagation()}
+                                  />
+                                }
+                              />
+                            ) : null;
+                          })}
+                        </Box>
+                      )
+                    }
+                  >
+                    {tracks_ddl.map((t) => (
+                      <MenuItem key={t.value} value={t.value}>
+                        <Checkbox
+                          checked={formik.values.trackIds.includes(t.value)}
+                        />
+                        <ListItemText primary={t.label} />
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {formik.touched.trackIds && formik.errors.trackIds && (
+                    <FormHelperText>{formik.errors.trackIds}</FormHelperText>
+                  )}
+                </FormControl>
+              </Grid2>
+            </Grid2>
+          </DialogContent>
+          <Divider />
+          <DialogActions>
+            <Button type="submit" fullWidth variant="contained">
+              {T.translate("general.save")}
+            </Button>
+          </DialogActions>
+        </Box>
+      </FormikProvider>
+    </Dialog>
+  );
+};
+
+TrackChairDialog.propTypes = {
+  entity: PropTypes.object,
+  tracks: PropTypes.array.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired
+};
+
+export default TrackChairDialog;

--- a/src/pages/track_chairs/components/track-chair-dialog.js
+++ b/src/pages/track_chairs/components/track-chair-dialog.js
@@ -78,6 +78,7 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
       if (isSaving) return;
       setIsSaving(true);
       onSave(values)
+        .then(() => onClose())
         .catch(() => {})
         .finally(() => setIsSaving(false));
     }

--- a/src/pages/track_chairs/components/track-chair-dialog.js
+++ b/src/pages/track_chairs/components/track-chair-dialog.js
@@ -11,7 +11,7 @@
  * limitations under the License.
  * */
 
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import T from "i18n-react/dist/i18n-react";
 import { FormikProvider, useFormik } from "formik";
@@ -54,13 +54,9 @@ const toMemberOption = (member) => {
   return formatMemberOption(member);
 };
 
-const TrackChairDialog = ({
-  entity,
-  tracks,
-  isSaving = false,
-  onSave,
-  onClose
-}) => {
+const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
+  const [isSaving, setIsSaving] = useState(false);
+
   const formik = useFormik({
     initialValues: {
       id: entity?.id ?? 0,
@@ -78,7 +74,13 @@ const TrackChairDialog = ({
         .min(1, T.translate("validation.required"))
         .required(T.translate("validation.required"))
     }),
-    onSubmit: (values) => onSave(values)
+    onSubmit: (values) => {
+      if (isSaving) return;
+      setIsSaving(true);
+      onSave(values)
+        .catch(() => {})
+        .finally(() => setIsSaving(false));
+    }
   });
 
   useScrollToError(formik, true);
@@ -133,6 +135,7 @@ const TrackChairDialog = ({
                   placeholder={T.translate(
                     "track_chairs.placeholders.select_track_chair"
                   )}
+                  disabled={entity?.id > 0}
                 />
               </Grid2>
               <Grid2 size={12}>
@@ -230,7 +233,6 @@ const TrackChairDialog = ({
 TrackChairDialog.propTypes = {
   entity: PropTypes.object,
   tracks: PropTypes.array.isRequired,
-  isSaving: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired
 };

--- a/src/pages/track_chairs/components/track-chair-dialog.js
+++ b/src/pages/track_chairs/components/track-chair-dialog.js
@@ -63,7 +63,6 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
       member: toMemberOption(entity?.member ?? null),
       trackIds: entity?.trackIds ?? []
     },
-    enableReinitialize: true,
     validationSchema: yup.object().shape({
       member: yup
         .object()
@@ -84,6 +83,10 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
     }
   });
 
+  const handleOnClose = () => {
+    if (isSaving) return;
+    onClose();
+  };
   useScrollToError(formik, true);
 
   const title = entity?.id
@@ -97,7 +100,7 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
   return (
     <Dialog
       open
-      onClose={onClose}
+      onClose={handleOnClose}
       maxWidth="sm"
       fullWidth
       disableEscapeKeyDown={isSaving}
@@ -106,7 +109,7 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
         <Typography fontSize="1.5rem">{title}</Typography>
         <IconButton
           size="small"
-          onClick={onClose}
+          onClick={handleOnClose}
           sx={{ mr: 1 }}
           aria-label="close"
           disabled={isSaving}

--- a/src/pages/track_chairs/components/track-chair-dialog.js
+++ b/src/pages/track_chairs/components/track-chair-dialog.js
@@ -54,7 +54,13 @@ const toMemberOption = (member) => {
   return formatMemberOption(member);
 };
 
-const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
+const TrackChairDialog = ({
+  entity,
+  tracks,
+  isSaving = false,
+  onSave,
+  onClose
+}) => {
   const formik = useFormik({
     initialValues: {
       id: entity?.id ?? 0,
@@ -86,7 +92,13 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
   const tracks_ddl = tracks.map((t) => ({ label: t.name, value: t.id }));
 
   return (
-    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      disableEscapeKeyDown={isSaving}
+    >
       <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
         <Typography fontSize="1.5rem">{title}</Typography>
         <IconButton
@@ -94,6 +106,7 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
           onClick={onClose}
           sx={{ mr: 1 }}
           aria-label="close"
+          disabled={isSaving}
         >
           <CloseIcon fontSize="small" />
         </IconButton>
@@ -199,7 +212,12 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
           </DialogContent>
           <Divider />
           <DialogActions>
-            <Button type="submit" fullWidth variant="contained">
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={isSaving}
+            >
               {T.translate("general.save")}
             </Button>
           </DialogActions>
@@ -212,6 +230,7 @@ const TrackChairDialog = ({ entity, tracks, onSave, onClose }) => {
 TrackChairDialog.propTypes = {
   entity: PropTypes.object,
   tracks: PropTypes.array.isRequired,
+  isSaving: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired
 };

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -57,8 +57,8 @@ const TrackChairListPage = ({
   const [dialogEntity, setDialogEntity] = useState(null);
 
   useEffect(() => {
-    if (currentSummit) getTrackChairs();
-  }, []);
+    if (currentSummit?.id) getTrackChairs();
+  }, [currentSummit?.id]);
 
   const chairTracks = currentSummit.tracks.filter((t) => t.chair_visible);
 

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -56,8 +56,6 @@ const TrackChairListPage = ({
 }) => {
   const [dialogEntity, setDialogEntity] = useState(null);
 
-  if (!currentSummit.id) return <div />;
-
   useEffect(() => {
     if (currentSummit) getTrackChairs();
   }, []);
@@ -155,6 +153,8 @@ const TrackChairListPage = ({
     lineHeight: "2.4rem",
     letterSpacing: "0.4px"
   };
+
+  if (!currentSummit?.id) return <div />;
 
   return (
     <div className="container">

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -9,17 +9,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ * */
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import T from "i18n-react/dist/i18n-react";
-import Swal from "sweetalert2";
-import { Pagination } from "react-bootstrap";
-import Dropdown from "openstack-uicore-foundation/lib/components/inputs/dropdown"
-import FreeTextSearch from "openstack-uicore-foundation/lib/components/free-text-search"
-import MemberInput from "openstack-uicore-foundation/lib/components/inputs/member-input"
-import Table from "openstack-uicore-foundation/lib/components/table";
+import {
+  Box,
+  Button,
+  FormControl,
+  Grid2,
+  IconButton,
+  InputAdornment,
+  MenuItem,
+  Select
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import ClearIcon from "@mui/icons-material/Clear";
+import MuiTable from "openstack-uicore-foundation/lib/components/mui/table";
+import SearchInput from "openstack-uicore-foundation/lib/components/mui/search-input";
 import {
   getTrackChairs,
   deleteTrackChair,
@@ -27,272 +35,262 @@ import {
   addTrackChair,
   exportTrackChairs
 } from "../../actions/track-chair-actions";
+import { DEFAULT_CURRENT_PAGE } from "../../utils/constants";
+import TrackChairDialog from "./components/track-chair-dialog";
 
-import "../../styles/track-chair-list-page.less";
+const TrackChairListPage = ({
+  currentSummit,
+  trackChairs,
+  currentPage,
+  perPage,
+  term,
+  order,
+  orderDir,
+  totalTrackChairs,
+  trackId,
+  getTrackChairs,
+  deleteTrackChair,
+  saveTrackChair,
+  addTrackChair,
+  exportTrackChairs
+}) => {
+  const [dialogEntity, setDialogEntity] = useState(null);
 
-class TrackChairListPage extends React.Component {
-  constructor(props) {
-    super(props);
+  if (!currentSummit.id) return <div />;
 
-    this.state = {
-      showForm: false,
-      member: null,
-      trackIds: [],
-      trackId: null
-    };
-  }
+  useEffect(() => {
+    if (currentSummit) getTrackChairs();
+  }, []);
 
-  componentDidMount() {
-    const { currentSummit } = this.props;
-    if (currentSummit) {
-      this.props.getTrackChairs();
-    }
-  }
+  const chairTracks = currentSummit.tracks.filter((t) => t.chair_visible);
 
-  toggleForm = (open) => {
-    this.setState((state) => ({ showForm: open, member: null, trackIds: [] }));
-  };
-
-  handleChange = (ev) => {
-    const { value, id } = ev.target;
-    const isNew = id === "member";
-
-    this.setState((state) => ({
-      [id]: value,
-      trackId: isNew ? 0 : state.trackId
-    }));
-  };
-
-  handleEdit = (trackChairId) => {
-    const { trackChairs } = this.props;
-    const trackChair = trackChairs.find((s) => s.id === trackChairId);
-
-    this.setState({
-      member: trackChair.member,
-      trackIds: trackChair.categories.map((c) => c.id),
-      showForm: true,
-      trackId: trackChairId
-    });
-  };
-
-  handleSave = () => {
-    const { member, trackIds, trackId } = this.state;
-
-    if (trackId) {
-      this.props.saveTrackChair(trackId, trackIds).then(() => {
-        this.setState({ member: null, trackIds: [], showForm: false });
-      });
-    } else {
-      this.props.addTrackChair(member, trackIds).then(() => {
-        this.setState({ member: null, trackIds: [], showForm: false });
-      });
-    }
-  };
-
-  handleFilterByTrack = (ev) => {
-    const { value } = ev.target;
-    const { term, page, order, orderDir, perPage } = this.props;
-    this.props.getTrackChairs(value, term, page, perPage, order, orderDir);
-  };
-
-  handlePageChange = (page) => {
-    const { trackId, term, order, orderDir, perPage } = this.props;
-    this.props.getTrackChairs(trackId, term, page, perPage, order, orderDir);
-  };
-
-  handleSort = (index, key, dir, func) => {
-    const { trackId, term, page, perPage } = this.props;
-
-    this.props.getTrackChairs(trackId, term, page, perPage, key, dir);
-  };
-
-  handleSearch = (term) => {
-    const { trackId, order, orderDir, page, perPage } = this.props;
-    this.props.getTrackChairs(trackId, term, page, perPage, order, orderDir);
-  };
-
-  handleDelete = (trackChairId) => {
-    const { deleteTrackChair, trackChairs } = this.props;
-    const trackChair = trackChairs.find((s) => s.id === trackChairId);
-
-    Swal.fire({
-      title: T.translate("general.are_you_sure"),
-      text: `${T.translate("track_chairs.delete_warning")} ${trackChair.name}`,
-      type: "warning",
-      showCancelButton: true,
-      confirmButtonColor: "#DD6B55",
-      confirmButtonText: T.translate("general.yes_remove")
-    }).then(function (result) {
-      if (result.value) {
-        deleteTrackChair(trackChairId);
-      }
-    });
-  };
-
-  handleExport = () => {
-    const { trackChairs } = this.props;
-    this.props.exportTrackChairs(trackChairs);
-  };
-
-  render() {
-    const {
-      currentSummit,
-      trackChairs,
-      lastPage,
-      currentPage,
-      term,
+  const handleSearch = (searchTerm) => {
+    getTrackChairs(
+      trackId,
+      searchTerm,
+      DEFAULT_CURRENT_PAGE,
+      perPage,
       order,
-      orderDir,
-      totalTrackChairs
-    } = this.props;
-    const { showForm, member, trackIds } = this.state;
-    const disabledSave = trackIds.length === 0 || !member;
-
-    const columns = [
-      {
-        columnKey: "name",
-        value: T.translate("track_chairs.name"),
-        sortable: true
-      },
-      { columnKey: "trackNames", value: T.translate("track_chairs.track") }
-    ];
-
-    const table_options = {
-      sortCol: order,
-      sortDir: orderDir,
-      actions: {
-        edit: { onClick: this.handleEdit },
-        delete: { onClick: this.handleDelete }
-      }
-    };
-
-    const tracks_ddl = currentSummit.tracks
-      .filter((t) => t.chair_visible)
-      .map((t) => ({ label: t.name, value: t.id }));
-
-    if (!currentSummit.id) return <div />;
-
-    return (
-      <>
-        <div className="container">
-          <h3>
-            {" "}
-            {T.translate("track_chairs.list")} ({totalTrackChairs})
-          </h3>
-          <div className={"row"}>
-            <div className={"col-md-4"}>
-              <FreeTextSearch
-                value={term}
-                placeholder={T.translate("track_chairs.placeholders.search")}
-                onSearch={this.handleSearch}
-              />
-            </div>
-            <div className={"col-md-3"}>
-              <Dropdown
-                id="trackFilter"
-                onChange={this.handleFilterByTrack}
-                placeholder={T.translate(
-                  "track_chairs.placeholders.select_track"
-                )}
-                options={tracks_ddl}
-                clearable
-              />
-            </div>
-            <div className="col-md-5 text-right">
-              <button
-                className="btn btn-default right-space"
-                onClick={this.handleExport}
-              >
-                {T.translate("general.export")}
-              </button>
-              <button
-                className="btn btn-primary"
-                onClick={() => this.toggleForm(true)}
-              >
-                {T.translate("track_chairs.add")}
-              </button>
-            </div>
-          </div>
-
-          {showForm && (
-            <div className="add-new-wrapper row">
-              <div className="col-md-5">
-                <MemberInput
-                  id="member"
-                  value={member}
-                  onChange={this.handleChange}
-                  getOptionLabel={(member) => {
-                    return member.hasOwnProperty("email")
-                      ? `${member.first_name} ${member.last_name} (${member.email})`
-                      : `${member.first_name} ${member.last_name} (${member.id})`;
-                  }}
-                  placeholder={T.translate(
-                    "track_chairs.placeholders.select_track_chair"
-                  )}
-                />
-              </div>
-              <div className="col-md-5">
-                <Dropdown
-                  id="trackIds"
-                  value={trackIds}
-                  onChange={this.handleChange}
-                  placeholder={T.translate(
-                    "track_chairs.placeholders.select_track"
-                  )}
-                  options={tracks_ddl}
-                  isMulti
-                />
-              </div>
-              <div className="col-md-2">
-                <button
-                  className="btn btn-primary right-space"
-                  onClick={this.handleSave}
-                  disabled={disabledSave}
-                >
-                  {T.translate("general.save")}
-                </button>
-                <button
-                  className="btn btn-default"
-                  onClick={() => this.toggleForm(false)}
-                >
-                  {T.translate("general.cancel")}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {trackChairs.length === 0 ? (
-            <div className="no-items">
-              {T.translate("track_chairs.no_items")}
-            </div>
-          ) : (
-            <div>
-              <Table
-                options={table_options}
-                data={trackChairs}
-                columns={columns}
-                onSort={this.handleSort}
-              />
-              <Pagination
-                bsSize="medium"
-                prev
-                next
-                first
-                last
-                ellipsis
-                boundaryLinks
-                maxButtons={10}
-                items={lastPage}
-                activePage={currentPage}
-                onSelect={this.handlePageChange}
-              />
-            </div>
-          )}
-        </div>
-      </>
+      orderDir
     );
-  }
-}
+  };
+
+  const handleFilterByTrack = (ev) => {
+    getTrackChairs(
+      ev.target.value,
+      term,
+      DEFAULT_CURRENT_PAGE,
+      perPage,
+      order,
+      orderDir
+    );
+  };
+
+  const handleSort = (key, dir) => {
+    getTrackChairs(trackId, term, currentPage, perPage, key, dir);
+  };
+
+  const handlePageChange = (page) => {
+    getTrackChairs(trackId, term, page, perPage, order, orderDir);
+  };
+
+  const handlePerPageChange = (newPerPage) => {
+    getTrackChairs(
+      trackId,
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir
+    );
+  };
+
+  const handleNewTrackChair = () => {
+    setDialogEntity({});
+  };
+
+  const handleEdit = (trackChair) => {
+    setDialogEntity({
+      id: trackChair.id,
+      member: trackChair.member,
+      originalMemberId: trackChair.member.id,
+      trackIds: trackChair.categories.map((c) => c.id)
+    });
+  };
+
+  const handleDelete = (trackChairId) => {
+    deleteTrackChair(trackChairId);
+  };
+
+  const handleSave = ({ id, member, trackIds }) => {
+    const newMember = dialogEntity?.originalMemberId !== member?.value;
+    const action =
+      !id || newMember
+        ? addTrackChair({ id: member.value }, trackIds)
+        : saveTrackChair(id, trackIds);
+    action.then(() => setDialogEntity(null));
+  };
+
+  const handleClose = () => {
+    setDialogEntity(null);
+  };
+
+  const columns = [
+    {
+      columnKey: "name",
+      header: T.translate("track_chairs.name"),
+      sortable: true
+    },
+    { columnKey: "trackNames", header: T.translate("track_chairs.track") }
+  ];
+
+  const table_options = { sortCol: order, sortDir: orderDir };
+
+  const tracks_ddl = chairTracks.map((t) => ({ label: t.name, value: t.id }));
+
+  const buttonSx = {
+    height: "36px",
+    padding: "6px 16px",
+    fontSize: "1.4rem",
+    lineHeight: "2.4rem",
+    letterSpacing: "0.4px"
+  };
+
+  return (
+    <div className="container">
+      <h3>{T.translate("track_chairs.list")}</h3>
+      <Grid2
+        container
+        spacing={1}
+        sx={{ justifyContent: "space-between", alignItems: "center", mb: 2 }}
+      >
+        <Grid2 size={2}>
+          <Box component="span">
+            {totalTrackChairs} {T.translate("track_chairs.track_chairs")}
+          </Box>
+        </Grid2>
+        <Grid2
+          container
+          size={10}
+          gap={1}
+          sx={{ justifyContent: "flex-end", alignItems: "center" }}
+        >
+          <Grid2 size={3}>
+            <SearchInput
+              term={term}
+              placeholder={T.translate("track_chairs.placeholders.search")}
+              onSearch={handleSearch}
+            />
+          </Grid2>
+          <Grid2 size={3}>
+            <FormControl
+              fullWidth
+              sx={{ "& .MuiOutlinedInput-root": { height: "36px" } }}
+            >
+              <Select
+                size="small"
+                value={trackId ?? ""}
+                onChange={handleFilterByTrack}
+                displayEmpty
+                renderValue={(selected) =>
+                  selected ? (
+                    tracks_ddl.find((t) => t.value === selected)?.label
+                  ) : (
+                    <span style={{ color: "#aaa" }}>
+                      {T.translate("track_chairs.placeholders.select_track")}
+                    </span>
+                  )
+                }
+                endAdornment={
+                  trackId ? (
+                    <InputAdornment position="end" sx={{ mr: 2 }}>
+                      <IconButton
+                        size="small"
+                        onClick={() =>
+                          getTrackChairs(
+                            null,
+                            term,
+                            DEFAULT_CURRENT_PAGE,
+                            perPage,
+                            order,
+                            orderDir
+                          )
+                        }
+                      >
+                        <ClearIcon fontSize="small" />
+                      </IconButton>
+                    </InputAdornment>
+                  ) : null
+                }
+              >
+                {tracks_ddl.map((t) => (
+                  <MenuItem key={t.value} value={t.value}>
+                    {t.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid2>
+          <Grid2
+            size="auto"
+            gap={1}
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center"
+            }}
+          >
+            <Button
+              variant="outlined"
+              onClick={() => exportTrackChairs(trackChairs)}
+              sx={buttonSx}
+            >
+              {T.translate("general.export")}
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleNewTrackChair}
+              startIcon={<AddIcon />}
+              sx={buttonSx}
+            >
+              {T.translate("track_chairs.add")}
+            </Button>
+          </Grid2>
+        </Grid2>
+      </Grid2>
+
+      {trackChairs.length === 0 ? (
+        <div>{T.translate("track_chairs.no_items")}</div>
+      ) : (
+        <MuiTable
+          columns={columns}
+          data={trackChairs}
+          options={table_options}
+          perPage={perPage}
+          currentPage={currentPage}
+          totalRows={totalTrackChairs}
+          onSort={handleSort}
+          onPageChange={handlePageChange}
+          onPerPageChange={handlePerPageChange}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          deleteDialogBody={(name) =>
+            `${T.translate("track_chairs.delete_warning")} ${name}`
+          }
+        />
+      )}
+
+      {dialogEntity !== null && (
+        <TrackChairDialog
+          entity={dialogEntity}
+          tracks={chairTracks}
+          onSave={handleSave}
+          onClose={handleClose}
+        />
+      )}
+    </div>
+  );
+};
 
 const mapStateToProps = ({ currentSummitState, trackChairListState }) => ({
   currentSummit: currentSummitState.currentSummit,

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -125,7 +125,16 @@ const TrackChairListPage = ({
   };
 
   const handleDelete = (trackChairId) => {
-    deleteTrackChair(trackChairId);
+    deleteTrackChair(trackChairId).then(() =>
+      getTrackChairs(
+        trackId,
+        term,
+        DEFAULT_CURRENT_PAGE,
+        perPage,
+        order,
+        orderDir
+      )
+    );
   };
 
   const handleSave = ({ id, member, trackIds }) => {

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -126,7 +126,16 @@ const TrackChairListPage = ({
       !id || newMember
         ? addTrackChair({ id: member.value }, trackIds)
         : saveTrackChair(id, trackIds);
-    return action;
+    return action.then(() =>
+      getTrackChairs(
+        trackId,
+        term,
+        DEFAULT_CURRENT_PAGE,
+        perPage,
+        order,
+        orderDir
+      )
+    );
   };
 
   const handleClose = () => {

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -126,7 +126,7 @@ const TrackChairListPage = ({
       !id || newMember
         ? addTrackChair({ id: member.value }, trackIds)
         : saveTrackChair(id, trackIds);
-    return action.then(() => setDialogEntity(null));
+    return action;
   };
 
   const handleClose = () => {

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -55,7 +55,6 @@ const TrackChairListPage = ({
   exportTrackChairs
 }) => {
   const [dialogEntity, setDialogEntity] = useState(null);
-  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (currentSummit?.id) getTrackChairs();
@@ -122,18 +121,15 @@ const TrackChairListPage = ({
   };
 
   const handleSave = ({ id, member, trackIds }) => {
-    if (isSaving) return;
-    setIsSaving(true);
     const newMember = dialogEntity?.originalMemberId !== member?.value;
     const action =
       !id || newMember
         ? addTrackChair({ id: member.value }, trackIds)
         : saveTrackChair(id, trackIds);
-    action.then(() => setDialogEntity(null)).finally(() => setIsSaving(false));
+    return action.then(() => setDialogEntity(null));
   };
 
   const handleClose = () => {
-    if (isSaving) return;
     setDialogEntity(null);
   };
 
@@ -246,7 +242,7 @@ const TrackChairListPage = ({
           >
             <Button
               variant="outlined"
-              onClick={() => exportTrackChairs(trackChairs)}
+              onClick={() => exportTrackChairs()}
               sx={buttonSx}
             >
               {T.translate("general.export")}
@@ -288,7 +284,6 @@ const TrackChairListPage = ({
         <TrackChairDialog
           entity={dialogEntity}
           tracks={chairTracks}
-          isSaving={isSaving}
           onSave={handleSave}
           onClose={handleClose}
         />

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -38,6 +38,14 @@ import {
 import { DEFAULT_CURRENT_PAGE } from "../../utils/constants";
 import TrackChairDialog from "./components/track-chair-dialog";
 
+const buttonSx = {
+  height: "36px",
+  padding: "6px 16px",
+  fontSize: "1.4rem",
+  lineHeight: "2.4rem",
+  letterSpacing: "0.4px"
+};
+
 const TrackChairListPage = ({
   currentSummit,
   trackChairs,
@@ -54,13 +62,14 @@ const TrackChairListPage = ({
   addTrackChair,
   exportTrackChairs
 }) => {
-  const [dialogEntity, setDialogEntity] = useState(null);
+  const [memberEdit, setMemberEdit] = useState(null);
 
   useEffect(() => {
     if (currentSummit?.id) getTrackChairs();
   }, [currentSummit?.id]);
 
-  const chairTracks = currentSummit.tracks.filter((t) => t.chair_visible);
+  const chairTracks =
+    currentSummit?.tracks?.filter((t) => t.chair_visible) ?? [];
 
   const handleSearch = (searchTerm) => {
     getTrackChairs(
@@ -85,7 +94,7 @@ const TrackChairListPage = ({
   };
 
   const handleSort = (key, dir) => {
-    getTrackChairs(trackId, term, currentPage, perPage, key, dir);
+    getTrackChairs(trackId, term, DEFAULT_CURRENT_PAGE, perPage, key, dir);
   };
 
   const handlePageChange = (page) => {
@@ -104,14 +113,13 @@ const TrackChairListPage = ({
   };
 
   const handleNewTrackChair = () => {
-    setDialogEntity({});
+    setMemberEdit({});
   };
 
   const handleEdit = (trackChair) => {
-    setDialogEntity({
+    setMemberEdit({
       id: trackChair.id,
       member: trackChair.member,
-      originalMemberId: trackChair.member.id,
       trackIds: trackChair.categories.map((c) => c.id)
     });
   };
@@ -121,25 +129,23 @@ const TrackChairListPage = ({
   };
 
   const handleSave = ({ id, member, trackIds }) => {
-    const newMember = dialogEntity?.originalMemberId !== member?.value;
-    const action =
-      !id || newMember
-        ? addTrackChair({ id: member.value }, trackIds)
-        : saveTrackChair(id, trackIds);
-    return action.then(() =>
+    const action = !id
+      ? addTrackChair({ id: member.value }, trackIds)
+      : saveTrackChair(id, trackIds);
+    return action.then(() => {
       getTrackChairs(
         trackId,
         term,
-        DEFAULT_CURRENT_PAGE,
+        !id ? DEFAULT_CURRENT_PAGE : currentPage,
         perPage,
         order,
         orderDir
-      )
-    );
+      ).catch(() => {});
+    });
   };
 
   const handleClose = () => {
-    setDialogEntity(null);
+    setMemberEdit(null);
   };
 
   const columns = [
@@ -154,14 +160,6 @@ const TrackChairListPage = ({
   const table_options = { sortCol: order, sortDir: orderDir };
 
   const tracks_ddl = chairTracks.map((t) => ({ label: t.name, value: t.id }));
-
-  const buttonSx = {
-    height: "36px",
-    padding: "6px 16px",
-    fontSize: "1.4rem",
-    lineHeight: "2.4rem",
-    letterSpacing: "0.4px"
-  };
 
   if (!currentSummit?.id) return <div />;
 
@@ -289,9 +287,9 @@ const TrackChairListPage = ({
         />
       )}
 
-      {dialogEntity !== null && (
+      {memberEdit !== null && (
         <TrackChairDialog
-          entity={dialogEntity}
+          entity={memberEdit}
           tracks={chairTracks}
           onSave={handleSave}
           onClose={handleClose}

--- a/src/pages/track_chairs/track-chair-list-page.js
+++ b/src/pages/track_chairs/track-chair-list-page.js
@@ -55,6 +55,7 @@ const TrackChairListPage = ({
   exportTrackChairs
 }) => {
   const [dialogEntity, setDialogEntity] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (currentSummit?.id) getTrackChairs();
@@ -121,15 +122,18 @@ const TrackChairListPage = ({
   };
 
   const handleSave = ({ id, member, trackIds }) => {
+    if (isSaving) return;
+    setIsSaving(true);
     const newMember = dialogEntity?.originalMemberId !== member?.value;
     const action =
       !id || newMember
         ? addTrackChair({ id: member.value }, trackIds)
         : saveTrackChair(id, trackIds);
-    action.then(() => setDialogEntity(null));
+    action.then(() => setDialogEntity(null)).finally(() => setIsSaving(false));
   };
 
   const handleClose = () => {
+    if (isSaving) return;
     setDialogEntity(null);
   };
 
@@ -284,6 +288,7 @@ const TrackChairListPage = ({
         <TrackChairDialog
           entity={dialogEntity}
           tracks={chairTracks}
+          isSaving={isSaving}
           onSave={handleSave}
           onClose={handleClose}
         />

--- a/src/reducers/track_chairs/__tests__/track-chair-list-reducer.test.js
+++ b/src/reducers/track_chairs/__tests__/track-chair-list-reducer.test.js
@@ -1,0 +1,29 @@
+import trackChairListReducer from "../track-chair-list-reducer";
+import { TRACK_CHAIR_ADDED } from "../../../actions/track-chair-actions";
+
+describe("trackChairListReducer", () => {
+  test("formats the name with the member's email when a track chair is added, matching the list load format", () => {
+    const initialState = {
+      trackChairs: [],
+      totalTrackChairs: 0
+    };
+
+    const result = trackChairListReducer(initialState, {
+      type: TRACK_CHAIR_ADDED,
+      payload: {
+        response: {
+          id: 99,
+          member: {
+            id: 42,
+            first_name: "Jane",
+            last_name: "Doe",
+            email: "jane@example.com"
+          },
+          categories: [{ id: 1, name: "Track A" }]
+        }
+      }
+    });
+
+    expect(result.trackChairs[0].name).toBe("Jane Doe (jane@example.com)");
+  });
+});

--- a/src/reducers/track_chairs/track-chair-list-reducer.js
+++ b/src/reducers/track_chairs/track-chair-list-reducer.js
@@ -9,7 +9,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ * */
+
+import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 
 import {
   RECEIVE_TRACK_CHAIRS,
@@ -18,9 +20,7 @@ import {
   TRACK_CHAIR_DELETED,
   TRACK_CHAIR_UPDATED
 } from "../../actions/track-chair-actions";
-
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 
 const DEFAULT_STATE = {
   trackChairs: [],
@@ -42,9 +42,9 @@ const trackChairListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_TRACK_CHAIRS: {
-      const { order, orderDir, term, trackId } = payload;
+      const { order, orderDir, term, trackId, perPage } = payload;
 
-      return { ...state, order, orderDir, term, trackId };
+      return { ...state, order, orderDir, term, trackId, perPage };
     }
     case RECEIVE_TRACK_CHAIRS: {
       const { total, last_page, current_page, data } = payload.response;
@@ -57,7 +57,7 @@ const trackChairListReducer = (state = DEFAULT_STATE, action) => {
 
       return {
         ...state,
-        trackChairs: trackChairs,
+        trackChairs,
         currentPage: current_page,
         totalTrackChairs: total,
         lastPage: last_page

--- a/src/reducers/track_chairs/track-chair-list-reducer.js
+++ b/src/reducers/track_chairs/track-chair-list-reducer.js
@@ -42,9 +42,17 @@ const trackChairListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_TRACK_CHAIRS: {
-      const { order, orderDir, term, trackId, perPage } = payload;
+      const { order, orderDir, term, trackId, page, perPage } = payload;
 
-      return { ...state, order, orderDir, term, trackId, perPage };
+      return {
+        ...state,
+        order,
+        orderDir,
+        term,
+        trackId,
+        currentPage: page,
+        perPage
+      };
     }
     case RECEIVE_TRACK_CHAIRS: {
       const { total, last_page, current_page, data } = payload.response;

--- a/src/reducers/track_chairs/track-chair-list-reducer.js
+++ b/src/reducers/track_chairs/track-chair-list-reducer.js
@@ -76,7 +76,7 @@ const trackChairListReducer = (state = DEFAULT_STATE, action) => {
       newTrackChair.trackNames = newTrackChair.categories
         .map((c) => c.name)
         .join(", ");
-      newTrackChair.name = `${newTrackChair.member.first_name} ${newTrackChair.member.last_name}`;
+      newTrackChair.name = `${newTrackChair.member.first_name} ${newTrackChair.member.last_name} (${newTrackChair.member.email})`;
 
       return { ...state, trackChairs: [...state.trackChairs, newTrackChair] };
     }

--- a/src/styles/track-chair-list-page.less
+++ b/src/styles/track-chair-list-page.less
@@ -1,8 +1,0 @@
-.add-new-wrapper {
-  background-color: #e7e5e5;
-  min-height: 100px;
-  padding-top: 30px;
-  border: 1px solid gray;
-  margin: 20px 0 20px;
-  border-radius: 4px;
-}


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9pc89t

<img width="1212" height="895" alt="image" src="https://github.com/user-attachments/assets/6fddb12d-fa86-42f5-bf08-6da5fa70443b" />
<img width="673" height="728" alt="image" src="https://github.com/user-attachments/assets/375a975b-73e4-487c-aeb8-864ad927c1aa" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a modal dialog for creating/editing track chairs, with member autocomplete, multi-track selection, and validation.
* **Refactor**
  * Rebuilt the track chair list page as a hooks-based flow using a Material-UI table and dialog-driven add/edit/delete.
* **Bug Fixes**
  * Improved action error handling with snackbars, ensured loading state clears consistently, and enhanced request tracking for track chair queries and CSV/export.
* **Documentation**
  * Updated track chair deletion confirmation text.
* **Tests**
  * Added Jest/RTL coverage for the track chair list page and the dialog’s validation, save, and disabled-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->