### PR TITLE
fix(promocode): preserve ticket type chip labels after validation error

### DIFF
--- a/src/actions/promocode-actions.js
+++ b/src/actions/promocode-actions.js
@@ -147,6 +147,12 @@ const normalizeEntity = (entity) => {
     normalizedEntity.tags = entity.tags.map((e) => e.tag);
   }
 
+  if (Array.isArray(entity.allowed_ticket_types)) {
+    normalizedEntity.allowed_ticket_types = entity.allowed_ticket_types.map(
+      (tt) => (typeof tt === "object" && tt !== null ? tt.id : tt)
+    );
+  }
+
   delete normalizedEntity.owner;
   delete normalizedEntity.owner_id;
   delete normalizedEntity.speaker;

--- a/src/components/forms/promocode-form/__tests__/promocode-form.integration.test.js
+++ b/src/components/forms/promocode-form/__tests__/promocode-form.integration.test.js
@@ -600,3 +600,37 @@ describe("regression — non-DomainAuthorized classes are unaffected by the layo
     }
   );
 });
+
+describe("regression — handleSubmit must not dehydrate allowed_ticket_types", () => {
+  // Reproduces the "Ticket Types reverts to undefined" bug (Jam
+  // b1566c62-c802-4f43-b093-9c5c2f5a5fde, ClickUp 86b9v01bt). Pre-fix,
+  // handleSubmit mutated state.entity.allowed_ticket_types from [{id, name}]
+  // to [id]; on a 412, the form re-rendered with raw IDs, and the
+  // openstack-uicore TicketTypesInput's getOptionLabel = `${e.name}` produced
+  // the literal string "undefined" for each chip. The action layer
+  // (normalizeEntity in promocode-actions.js) is responsible for the
+  // hydrated → API-shape conversion; the form must hand off untouched
+  // option objects.
+  it("passes onSubmit an entity whose allowed_ticket_types retain {id,name} objects", () => {
+    const onSubmit = jest.fn();
+    const ticketType = { id: 197, name: "Early Access Members" };
+    renderForm(
+      baseEntity({
+        class_name: "DOMAIN_AUTHORIZED_PROMO_CODE",
+        allowed_email_domains: ["@valid.com"],
+        allowed_ticket_types: [ticketType]
+      }),
+      { onSubmit }
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submittedEntity = onSubmit.mock.calls[0][0];
+    expect(submittedEntity.allowed_ticket_types).toEqual([ticketType]);
+    expect(submittedEntity.allowed_ticket_types[0]).toMatchObject({
+      id: 197,
+      name: "Early Access Members"
+    });
+  });
+});

--- a/src/components/forms/promocode-form/index.js
+++ b/src/components/forms/promocode-form/index.js
@@ -141,12 +141,6 @@ class PromocodeForm extends React.Component {
     const { entity } = this.state;
     const typeScope = this.fragmentParser.getParam("type");
 
-    if (entity.allowed_ticket_types.length > 0) {
-      entity.allowed_ticket_types = entity.allowed_ticket_types.map(
-        (tt) => tt.id
-      );
-    }
-
     if (this.validate()) {
       onSubmit(entity, typeScope === "sponsor");
     }


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9v01bt
ref: https://jam.dev/c/b1566c62-c802-4f43-b093-9c5c2f5a5fde

## Summary

After a server validation error (e.g. POST returning 412 for a missing required `code`), the Promo Code form's "Ticket Types" chips would revert to displaying the literal string `undefined` for each previously-selected option.

Two-layer corruption:

1. `PromocodeForm.handleSubmit` mutated `state.entity.allowed_ticket_types` from `[{id, name, …}]` to `[id, …]` in place, before calling `onSubmit`.
2. `savePromocode` dispatches `UPDATE_PROMOCODE` (start action) with that same entity reference; the reducer (`promocode-reducer.js:131-133`) spreads the now-dehydrated payload into `state.entity`. On a 412 no `PROMOCODE_ADDED` re-hydration runs, so the form re-renders with raw IDs. uicore's `TicketTypesInput` defaults `getOptionLabel` to `` `${e.name}` `` — for a raw number `(197).name` is `undefined`, the template literal coerces it to the string `"undefined"`, and that's what every chip displays.

## Fix

- Remove the mutation block in `handleSubmit` — the form hands `onSubmit` the unmodified entity.
- Move the ID extraction into `normalizeEntity` in the action layer, alongside the existing `tags` mapping. Only the request body is dehydrated; redux state and the form's `state.entity` stay hydrated.

This also incidentally cures a latent symptom on the PUT path (existing-code edits): `PROMOCODE_UPDATED` doesn't re-hydrate from response, so post-fix successful PUTs also keep chips intact.

## Test plan

- [x] Added regression test in `promocode-form.integration.test.js` asserting `onSubmit` receives an entity whose `allowed_ticket_types` retains `{id, name}` objects. Verified to fail pre-fix (received `[197]`), pass post-fix.
- [x] All 31 promocode-form integration tests pass.
- [x] Manually reproduced the original Jam scenario in dev: created a `DOMAIN_AUTHORIZED_PROMO_CODE` with the email domains pre-populated and "Early Access Members" added, clicked Save without typing `code`, dismissed the 412 toast — chip still reads "Early Access Members" (was "undefined" pre-fix).

## Refs

- ClickUp: https://app.clickup.com/t/86b9v01bt
- Jam: https://jam.dev/c/b1566c62-c802-4f43-b093-9c5c2f5a5fde

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where promotional code ticket type data was being incomplete during form submission. Ticket type information is now properly preserved with all details intact.

* **Tests**
  * Added regression test to ensure promotional code forms correctly handle allowed ticket type data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->