### PR TITLE
fix: rename hideArchived props on sponsor forms and pages tabs

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
@@ -237,7 +237,7 @@ const SponsorFormsTab = ({
       managedForms.perPage,
       managedForms.order,
       managedForms.orderDir,
-      hideArchived
+      showArchived
     );
     getSponsorCustomizedForms(
       term,
@@ -245,7 +245,7 @@ const SponsorFormsTab = ({
       customizedForms.perPage,
       customizedForms.order,
       customizedForms.orderDir,
-      hideArchived
+      showArchived
     );
   };
 

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
@@ -227,7 +227,7 @@ const SponsorPagesTab = ({
         perPage,
         order,
         orderDir,
-        hideArchived
+        showArchived
       );
     });
   };


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9wgk9y

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archive filter state not correctly refreshing when closing sponsor forms
  * Fixed archive filter state not correctly updating after deleting sponsor pages

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/932)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->