### PR TITLE
fix: reload managed page on customized pages delete 

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
@@ -166,13 +166,20 @@ const SponsorFormsTab = ({
 
   const handleCustomizedDelete = (itemId) => {
     deleteSponsorCustomizedForm(itemId).then(() => {
-      const { perPage, order, orderDir } = customizedForms;
       getSponsorCustomizedForms(
         term,
         DEFAULT_CURRENT_PAGE,
-        perPage,
-        order,
-        orderDir,
+        customizedForms.perPage,
+        customizedForms.order,
+        customizedForms.orderDir,
+        showArchived
+      );
+      getSponsorManagedForms(
+        term,
+        DEFAULT_CURRENT_PAGE,
+        managedForms.perPage,
+        managedForms.order,
+        managedForms.orderDir,
         showArchived
       );
     });

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-pages-tab/index.js
@@ -220,13 +220,20 @@ const SponsorPagesTab = ({
 
   const handleCustomizedDelete = (itemId) => {
     deleteSponsorCustomizedPage(itemId).then(() => {
-      const { perPage, order, orderDir } = customizedPages;
       getSponsorCustomizedPages(
         term,
         DEFAULT_CURRENT_PAGE,
-        perPage,
-        order,
-        orderDir,
+        customizedPages.perPage,
+        customizedPages.order,
+        customizedPages.orderDir,
+        showArchived
+      );
+      getSponsorManagedPages(
+        term,
+        DEFAULT_CURRENT_PAGE,
+        managedPages.perPage,
+        managedPages.order,
+        managedPages.orderDir,
         showArchived
       );
     });


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9wgk9y

Signed-off-by: Tomás Castillo [tcastilloboireau@gmail.com](mailto:tcastilloboireau@gmail.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a customized sponsor form or page now properly refreshes both customized and managed items lists to ensure data consistency.
  * Current filters, search terms, and pagination settings are preserved after deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/935)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->