### PR TITLE
fix: add missing perPage parameter on REQUEST actions for form items

### DIFF
--- a/src/actions/form-template-item-actions.js
+++ b/src/actions/form-template-item-actions.js
@@ -114,7 +114,7 @@ export const getFormTemplateItems =
       createAction(RECEIVE_FORM_TEMPLATE_ITEMS),
       `${window.INVENTORY_API_BASE_URL}/api/v1/form-templates/${formTemplateId}/items`,
       snackbarErrorHandler,
-      { order, orderDir, page, term, showArchived }
+      { order, orderDir, page, perPage, term, showArchived }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });

--- a/src/actions/sponsor-forms-actions.js
+++ b/src/actions/sponsor-forms-actions.js
@@ -1109,7 +1109,7 @@ export const getSponsorFormItems =
       createAction(RECEIVE_SPONSOR_FORM_ITEMS),
       `${window.PURCHASES_API_URL}/api/v1/summits/${currentSummit.id}/show-forms/${formId}/items`,
       authErrorHandler,
-      { order, orderDir, page, showArchived }
+      { order, orderDir, page, perPage, showArchived }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });

--- a/src/reducers/sponsors/__tests__/sponsor-form-items-list-reducer.test.js
+++ b/src/reducers/sponsors/__tests__/sponsor-form-items-list-reducer.test.js
@@ -70,6 +70,7 @@ describe("SponsorFormItemsListReducer", () => {
           order: "date",
           orderDir: 2,
           page: 10,
+          perPage: 50,
           showArchived: true
         }
       });
@@ -79,6 +80,7 @@ describe("SponsorFormItemsListReducer", () => {
         order: "date",
         orderDir: 2,
         currentPage: 10,
+        perPage: 50,
         showArchived: true,
         items: []
       });

--- a/src/reducers/sponsors/sponsor-form-items-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-form-items-list-reducer.js
@@ -57,7 +57,7 @@ const sponsorFormItemsListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_SPONSOR_FORM_ITEMS: {
-      const { order, orderDir, page, showArchived } = payload;
+      const { order, orderDir, page, perPage, showArchived } = payload;
 
       return {
         ...state,
@@ -65,6 +65,7 @@ const sponsorFormItemsListReducer = (state = DEFAULT_STATE, action) => {
         orderDir,
         items: [],
         currentPage: page,
+        perPage,
         showArchived
       };
     }

--- a/src/reducers/sponsors_inventory/form-template-item-list-reducer.js
+++ b/src/reducers/sponsors_inventory/form-template-item-list-reducer.js
@@ -40,7 +40,7 @@ const formTemplateItemListReducer = (state = DEFAULT_STATE, action = {}) => {
       return DEFAULT_STATE;
     }
     case REQUEST_FORM_TEMPLATE_ITEMS: {
-      const { order, orderDir, page, ...rest } = payload;
+      const { order, orderDir, page, perPage, ...rest } = payload;
 
       if (
         order !== state.order ||
@@ -53,6 +53,7 @@ const formTemplateItemListReducer = (state = DEFAULT_STATE, action = {}) => {
           order,
           orderDir,
           currentPage: page,
+          perPage,
           ...rest
         };
       }
@@ -63,6 +64,7 @@ const formTemplateItemListReducer = (state = DEFAULT_STATE, action = {}) => {
         orderDir,
         formTemplateItems: [],
         currentPage: page,
+        perPage,
         ...rest
       };
     }

--- a/src/reducers/sponsors_inventory/inventory-item-list-reducer.js
+++ b/src/reducers/sponsors_inventory/inventory-item-list-reducer.js
@@ -49,7 +49,7 @@ const inventoryItemListReducer = (state = DEFAULT_STATE, action = {}) => {
       return DEFAULT_STATE;
     }
     case REQUEST_INVENTORY_ITEMS: {
-      const { order, orderDir, page, ...rest } = payload;
+      const { order, orderDir, page, perPage, ...rest } = payload;
 
       if (
         order !== state.order ||
@@ -62,6 +62,7 @@ const inventoryItemListReducer = (state = DEFAULT_STATE, action = {}) => {
           order,
           orderDir,
           currentPage: page,
+          perPage,
           ...rest
         };
       }
@@ -72,6 +73,7 @@ const inventoryItemListReducer = (state = DEFAULT_STATE, action = {}) => {
         orderDir,
         inventoryItems: [],
         currentPage: page,
+        perPage,
         ...rest
       };
     }


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b8bczw1

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request payloads now include the items-per-page setting so list fetches respect per-page preferences.
  * List views (form templates, sponsor forms, inventory) now preserve and update the items-per-page value when fetching or resetting results.
  * Tests updated to include the per-page value in relevant fetch action assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->