### PR TITLE
fix: adjust return order on normalizeSelectAllField function

### DIFF
--- a/src/utils/__tests__/methods.test.js
+++ b/src/utils/__tests__/methods.test.js
@@ -86,6 +86,24 @@ describe("getMediaInputValue", () => {
       });
     });
 
+    it.each([[], null, undefined])(
+      "should return apply_to_all true when allSelected is true and items is %s",
+      (items) => {
+        expect(
+          normalizeSelectAllField(items, "apply_to_all", "items", true)
+        ).toEqual({ apply_to_all: true, items: [] });
+      }
+    );
+
+    it.each([[], null, undefined])(
+      "should return apply_to_all false when allSelected is false and items is %s",
+      (items) => {
+        expect(
+          normalizeSelectAllField(items, "apply_to_all", "items", false)
+        ).toEqual({ apply_to_all: false, items: [] });
+      }
+    );
+
     it("should return array of ids when items are objects with id", () => {
       expect(
         normalizeSelectAllField([{ id: 1 }, { id: 2 }], "apply_to_all", "items")

--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -601,19 +601,19 @@ export const normalizeSelectAllField = (
   listName,
   allSelected
 ) => {
-  if (!items?.length)
-    return {
-      [flagName]: false,
-      [listName]: []
-    };
-
-  const isAllSelected = allSelected ?? items.includes("all");
+  const isAllSelected = allSelected ?? items?.includes("all");
   if (isAllSelected) {
     return {
       [flagName]: true,
       [listName]: []
     };
   }
+
+  if (!items?.length)
+    return {
+      [flagName]: false,
+      [listName]: []
+    };
   return {
     [flagName]: false,
     [listName]: items.map((a) => a.id ?? a)


### PR DESCRIPTION
ref: https://app.clickup.com/t/86b9ydmgt

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Select-all behavior now respects an explicit "all selected" flag even when items are empty, null, or undefined, avoiding incorrect deactivation and ensuring consistent selection state.

* **Tests**
  * Added parameterized tests covering empty/null/undefined item lists to validate the normalized select-all behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->