### PR TITLE
feat(promo-codes): Tier 2 — search, type filter & multi-select delete for allowed email domains

### DIFF
--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -21,14 +21,21 @@ const typeOf = (entry) => {
 };
 
 const Row = React.memo(({ index, style, data }) => {
-  const { entry } = data.items[index];
+  const { items, selection, onToggle } = data;
+  const { entry, originalIndex } = items[index];
   return (
     <div
-      style={style}
+      style={{ ...style, display: "flex", alignItems: "center", gap: 8 }}
       data-testid={`manage-modal-row-${index}`}
       className="manage-modal-row"
     >
-      {entry}
+      <input
+        type="checkbox"
+        data-testid={`manage-modal-checkbox-${originalIndex}`}
+        checked={selection.has(originalIndex)}
+        onChange={() => onToggle(originalIndex)}
+      />
+      <span>{entry}</span>
     </div>
   );
 });
@@ -45,6 +52,7 @@ const ManageAllowedEmailDomainsModal = ({
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
+  const [selection, setSelection] = useState(() => new Set());
   const listRef = useRef(null);
 
   // Intentionally depend only on `show`: snapshot `existing` when the modal opens
@@ -57,6 +65,7 @@ const ManageAllowedEmailDomainsModal = ({
       setSearchInput("");
       setSearch("");
       setTypeFilter("all");
+      setSelection(new Set());
     }
   }, [show]);
 
@@ -64,6 +73,10 @@ const ManageAllowedEmailDomainsModal = ({
     const id = setTimeout(() => setSearch(searchInput), SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(id);
   }, [searchInput]);
+
+  useEffect(() => {
+    setSelection(new Set());
+  }, [search, typeFilter]);
 
   const handleAddDomains = useCallback(() => {
     const rows = parseTextBlob(draftText);
@@ -93,6 +106,15 @@ const ManageAllowedEmailDomainsModal = ({
       listRef.current.scrollToItem(next.length - 1, "end");
     }
   }, [draftText, working, search, searchInput, typeFilter]);
+
+  const handleToggleSelect = useCallback((originalIndex) => {
+    setSelection((prev) => {
+      const next = new Set(prev);
+      if (next.has(originalIndex)) next.delete(originalIndex);
+      else next.add(originalIndex);
+      return next;
+    });
+  }, []);
 
   const handleKeyDown = (ev) => {
     if (ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
@@ -139,7 +161,19 @@ const ManageAllowedEmailDomainsModal = ({
     });
   }, [working, search, typeFilter]);
 
-  const itemData = useMemo(() => ({ items: visible }), [visible]);
+  const handleSelectAll = useCallback(() => {
+    setSelection(new Set(visible.map((x) => x.originalIndex)));
+  }, [visible]);
+
+  const handleDeleteSelected = useCallback(() => {
+    setWorking((prev) => prev.filter((_, idx) => !selection.has(idx)));
+    setSelection(new Set());
+  }, [selection]);
+
+  const itemData = useMemo(
+    () => ({ items: visible, selection, onToggle: handleToggleSelect }),
+    [visible, selection, handleToggleSelect]
+  );
 
   return (
     <Modal show={show} onHide={handleCancel} bsSize="large">
@@ -214,10 +248,33 @@ const ManageAllowedEmailDomainsModal = ({
         )}
         <div
           className="manage-modal-count"
-          data-testid="manage-modal-count"
-          style={{ marginBottom: 4 }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 4
+          }}
         >
-          {countText}
+          <span data-testid="manage-modal-count">{countText}</span>
+          <button
+            type="button"
+            className="btn btn-default btn-xs"
+            data-testid="manage-modal-select-all"
+            onClick={handleSelectAll}
+          >
+            {T.translate("edit_promocode.manage_modal.select_all")}
+          </button>
+          <button
+            type="button"
+            className="btn btn-danger btn-xs"
+            data-testid="manage-modal-delete-selected"
+            onClick={handleDeleteSelected}
+            disabled={selection.size === 0}
+          >
+            {T.translate("edit_promocode.manage_modal.delete_selected", {
+              n: selection.size
+            })}
+          </button>
         </div>
         <FixedSizeList
           ref={listRef}

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -81,16 +81,16 @@ const ManageAllowedEmailDomainsModal = ({
     setDraftText("");
 
     // Adds append to the end of the working copy. If a search filter is
-    // active the new entries may be filtered out of view — clear it so the
-    // additions are visible, and only autoscroll when the unfiltered list
-    // index space matches `working`.
-    if (search !== "") {
+    // active — or a search is pending in the debounce window (searchInput
+    // typed but `search` state not yet updated) — clear both so the additions
+    // are visible. Only autoscroll when the list is fully unfiltered.
+    if (search !== "" || searchInput !== "") {
       setSearchInput("");
       setSearch("");
     } else if (listRef.current && next.length > 0) {
       listRef.current.scrollToItem(next.length - 1, "end");
     }
-  }, [draftText, working, search]);
+  }, [draftText, working, search, searchInput]);
 
   const handleKeyDown = (ev) => {
     if (ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -168,12 +168,7 @@ const ManageAllowedEmailDomainsModal = ({
             className="form-control"
             style={{ maxWidth: 180 }}
             value={typeFilter}
-            onChange={(ev) => {
-              // Flush any pending debounced search so the new type filter
-              // applies against the search the user already typed.
-              setSearch(searchInput);
-              setTypeFilter(ev.target.value);
-            }}
+            onChange={(ev) => setTypeFilter(ev.target.value)}
           >
             <option value="all">
               {T.translate("edit_promocode.manage_modal.filter.all")}

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -12,9 +12,17 @@ import { parseTextBlob, classifyEntries } from "./bulk-input-parser";
 
 const ROW_HEIGHT = 32;
 const LIST_HEIGHT = 320;
+const SEARCH_DEBOUNCE_MS = 150;
+
+// eslint-disable-next-line no-unused-vars
+const _typeOf = (entry) => {
+  if (entry.startsWith("@")) return "at_domain";
+  if (entry.startsWith(".")) return "tld";
+  return "email";
+};
 
 const Row = React.memo(({ index, style, data }) => {
-  const entry = data[index];
+  const { entry } = data.items[index];
   return (
     <div
       style={style}
@@ -35,6 +43,8 @@ const ManageAllowedEmailDomainsModal = ({
   const [working, setWorking] = useState([]);
   const [draftText, setDraftText] = useState("");
   const [toast, setToast] = useState(null);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
   const listRef = useRef(null);
 
   // Intentionally depend only on `show`: snapshot `existing` when the modal opens
@@ -44,8 +54,15 @@ const ManageAllowedEmailDomainsModal = ({
       setWorking(Array.isArray(existing) ? [...existing] : []);
       setDraftText("");
       setToast(null);
+      setSearchInput("");
+      setSearch("");
     }
   }, [show]);
+
+  useEffect(() => {
+    const id = setTimeout(() => setSearch(searchInput), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [searchInput]);
 
   const handleAddDomains = useCallback(() => {
     const rows = parseTextBlob(draftText);
@@ -63,10 +80,17 @@ const ManageAllowedEmailDomainsModal = ({
     });
     setDraftText("");
 
-    if (listRef.current && next.length > 0) {
+    // Adds append to the end of the working copy. If a search filter is
+    // active the new entries may be filtered out of view — clear it so the
+    // additions are visible, and only autoscroll when the unfiltered list
+    // index space matches `working`.
+    if (search !== "") {
+      setSearchInput("");
+      setSearch("");
+    } else if (listRef.current && next.length > 0) {
       listRef.current.scrollToItem(next.length - 1, "end");
     }
-  }, [draftText, working]);
+  }, [draftText, working, search]);
 
   const handleKeyDown = (ev) => {
     if (ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
@@ -100,6 +124,18 @@ const ManageAllowedEmailDomainsModal = ({
     }
   );
 
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const indexed = working.map((entry, originalIndex) => ({
+      entry,
+      originalIndex
+    }));
+    if (!q) return indexed;
+    return indexed.filter((x) => x.entry.toLowerCase().includes(q));
+  }, [working, search]);
+
+  const itemData = useMemo(() => ({ items: visible }), [visible]);
+
   return (
     <Modal show={show} onHide={handleCancel} bsSize="large">
       <Modal.Header closeButton>
@@ -108,6 +144,21 @@ const ManageAllowedEmailDomainsModal = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
+        <div
+          className="manage-modal-controls"
+          style={{ display: "flex", gap: 8, marginBottom: 12 }}
+        >
+          <input
+            type="text"
+            data-testid="manage-modal-search"
+            className="form-control"
+            value={searchInput}
+            placeholder={T.translate(
+              "edit_promocode.manage_modal.search_placeholder"
+            )}
+            onChange={(ev) => setSearchInput(ev.target.value)}
+          />
+        </div>
         <div className="manage-modal-add-section" style={{ marginBottom: 12 }}>
           <textarea
             data-testid="manage-modal-textarea"
@@ -147,9 +198,9 @@ const ManageAllowedEmailDomainsModal = ({
           ref={listRef}
           height={LIST_HEIGHT}
           width="100%"
-          itemCount={working.length}
+          itemCount={visible.length}
           itemSize={ROW_HEIGHT}
-          itemData={working}
+          itemData={itemData}
         >
           {Row}
         </FixedSizeList>

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -54,6 +54,7 @@ const ManageAllowedEmailDomainsModal = ({
   const [typeFilter, setTypeFilter] = useState("all");
   const [selection, setSelection] = useState(() => new Set());
   const listRef = useRef(null);
+  const scrollToEndRef = useRef(false);
 
   // Intentionally depend only on `show`: snapshot `existing` when the modal opens
   // and ignore subsequent prop changes — modal owns the working copy until Done/Cancel.
@@ -94,16 +95,19 @@ const ManageAllowedEmailDomainsModal = ({
     });
     setDraftText("");
 
-    // Adds append to the end of the working copy. If a search or type filter is
-    // active — or a search is pending in the debounce window (searchInput
-    // typed but `search` state not yet updated) — clear all filters so the
-    // additions are visible. Only autoscroll when the list is fully unfiltered.
+    // Adds append to the end of the working copy. Clear any active or pending
+    // filter so the additions are not filtered out of the visible list.
     if (search !== "" || searchInput !== "" || typeFilter !== "all") {
       setSearchInput("");
       setSearch("");
       setTypeFilter("all");
-    } else if (listRef.current && next.length > 0) {
-      listRef.current.scrollToItem(next.length - 1, "end");
+    }
+    // Defer the autoscroll: `setWorking` above is batched and not yet committed,
+    // so react-window still has the old itemCount and would clamp the target
+    // index to the old last row. A flag + post-render effect scrolls once the
+    // list has re-rendered with the new (larger) itemCount.
+    if (additions.length > 0) {
+      scrollToEndRef.current = true;
     }
   }, [draftText, working, search, searchInput, typeFilter]);
 
@@ -160,6 +164,13 @@ const ManageAllowedEmailDomainsModal = ({
       return true;
     });
   }, [working, search, typeFilter]);
+
+  useEffect(() => {
+    if (scrollToEndRef.current && listRef.current && visible.length > 0) {
+      listRef.current.scrollToItem(visible.length - 1, "end");
+    }
+    scrollToEndRef.current = false;
+  }, [visible]);
 
   const handleSelectAll = useCallback(() => {
     setSelection(new Set(visible.map((x) => x.originalIndex)));

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -14,7 +14,6 @@ const ROW_HEIGHT = 32;
 const LIST_HEIGHT = 320;
 const SEARCH_DEBOUNCE_MS = 150;
 
-// eslint-disable-next-line no-unused-vars, unused-imports/no-unused-vars
 const typeOf = (entry) => {
   if (entry.startsWith("@")) return "at_domain";
   if (entry.startsWith(".")) return "tld";
@@ -45,6 +44,7 @@ const ManageAllowedEmailDomainsModal = ({
   const [toast, setToast] = useState(null);
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
   const listRef = useRef(null);
 
   // Intentionally depend only on `show`: snapshot `existing` when the modal opens
@@ -56,6 +56,7 @@ const ManageAllowedEmailDomainsModal = ({
       setToast(null);
       setSearchInput("");
       setSearch("");
+      setTypeFilter("all");
     }
   }, [show]);
 
@@ -80,17 +81,18 @@ const ManageAllowedEmailDomainsModal = ({
     });
     setDraftText("");
 
-    // Adds append to the end of the working copy. If a search filter is
+    // Adds append to the end of the working copy. If a search or type filter is
     // active — or a search is pending in the debounce window (searchInput
-    // typed but `search` state not yet updated) — clear both so the additions
-    // are visible. Only autoscroll when the list is fully unfiltered.
-    if (search !== "" || searchInput !== "") {
+    // typed but `search` state not yet updated) — clear all filters so the
+    // additions are visible. Only autoscroll when the list is fully unfiltered.
+    if (search !== "" || searchInput !== "" || typeFilter !== "all") {
       setSearchInput("");
       setSearch("");
+      setTypeFilter("all");
     } else if (listRef.current && next.length > 0) {
       listRef.current.scrollToItem(next.length - 1, "end");
     }
-  }, [draftText, working, search, searchInput]);
+  }, [draftText, working, search, searchInput, typeFilter]);
 
   const handleKeyDown = (ev) => {
     if (ev.key === "Enter" && (ev.metaKey || ev.ctrlKey)) {
@@ -130,9 +132,12 @@ const ManageAllowedEmailDomainsModal = ({
       entry,
       originalIndex
     }));
-    if (!q) return indexed;
-    return indexed.filter((x) => x.entry.toLowerCase().includes(q));
-  }, [working, search]);
+    return indexed.filter((x) => {
+      if (typeFilter !== "all" && typeOf(x.entry) !== typeFilter) return false;
+      if (q && !x.entry.toLowerCase().includes(q)) return false;
+      return true;
+    });
+  }, [working, search, typeFilter]);
 
   const itemData = useMemo(() => ({ items: visible }), [visible]);
 
@@ -158,6 +163,31 @@ const ManageAllowedEmailDomainsModal = ({
             )}
             onChange={(ev) => setSearchInput(ev.target.value)}
           />
+          <select
+            data-testid="manage-modal-type-filter"
+            className="form-control"
+            style={{ maxWidth: 180 }}
+            value={typeFilter}
+            onChange={(ev) => {
+              // Flush any pending debounced search so the new type filter
+              // applies against the search the user already typed.
+              setSearch(searchInput);
+              setTypeFilter(ev.target.value);
+            }}
+          >
+            <option value="all">
+              {T.translate("edit_promocode.manage_modal.filter.all")}
+            </option>
+            <option value="at_domain">
+              {T.translate("edit_promocode.manage_modal.filter.at_domain")}
+            </option>
+            <option value="tld">
+              {T.translate("edit_promocode.manage_modal.filter.tld")}
+            </option>
+            <option value="email">
+              {T.translate("edit_promocode.manage_modal.filter.email")}
+            </option>
+          </select>
         </div>
         <div className="manage-modal-add-section" style={{ marginBottom: 12 }}>
           <textarea

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -14,8 +14,8 @@ const ROW_HEIGHT = 32;
 const LIST_HEIGHT = 320;
 const SEARCH_DEBOUNCE_MS = 150;
 
-// eslint-disable-next-line no-unused-vars
-const _typeOf = (entry) => {
+// eslint-disable-next-line no-unused-vars, unused-imports/no-unused-vars
+const typeOf = (entry) => {
   if (entry.startsWith("@")) return "at_domain";
   if (entry.startsWith(".")) return "tld";
   return "email";

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -32,6 +32,9 @@ const Row = React.memo(({ index, style, data }) => {
       <input
         type="checkbox"
         data-testid={`manage-modal-checkbox-${originalIndex}`}
+        aria-label={T.translate("edit_promocode.manage_modal.row_select_aria", {
+          entry
+        })}
         checked={selection.has(originalIndex)}
         onChange={() => onToggle(originalIndex)}
       />
@@ -204,6 +207,7 @@ const ManageAllowedEmailDomainsModal = ({
             data-testid="manage-modal-search"
             className="form-control"
             value={searchInput}
+            aria-label={T.translate("edit_promocode.manage_modal.search_aria")}
             placeholder={T.translate(
               "edit_promocode.manage_modal.search_placeholder"
             )}
@@ -213,6 +217,9 @@ const ManageAllowedEmailDomainsModal = ({
             data-testid="manage-modal-type-filter"
             className="form-control"
             style={{ maxWidth: 180 }}
+            aria-label={T.translate(
+              "edit_promocode.manage_modal.type_filter_aria"
+            )}
             value={typeFilter}
             onChange={(ev) => setTypeFilter(ev.target.value)}
           >
@@ -236,6 +243,7 @@ const ManageAllowedEmailDomainsModal = ({
             className="form-control"
             rows={4}
             value={draftText}
+            aria-label={T.translate("edit_promocode.manage_modal.add_aria")}
             placeholder={T.translate("edit_promocode.manage_modal.add_helper")}
             onChange={(ev) => setDraftText(ev.target.value)}
             onKeyDown={handleKeyDown}

--- a/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/ManageAllowedEmailDomainsModal.jsx
@@ -71,9 +71,10 @@ const ManageAllowedEmailDomainsModal = ({
   }, [show]);
 
   useEffect(() => {
+    if (!show) return undefined;
     const id = setTimeout(() => setSearch(searchInput), SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(id);
-  }, [searchInput]);
+  }, [searchInput, show]);
 
   useEffect(() => {
     setSelection(new Set());

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -184,4 +184,39 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
       ).toHaveLength(2)
     );
   });
+
+  it("Add within debounce window clears pending search and keeps new entry visible", async () => {
+    // Open with one existing entry.
+    openModal(["@acme.com"]);
+
+    // Type a search term — fireEvent is synchronous, so the 150 ms debounce
+    // timeout has NOT fired yet: searchInput="acme", search="" still.
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+
+    // Immediately (same tick) add a domain that does NOT match "acme" — the
+    // bug would leave searchInput intact and then the deferred setSearch fires,
+    // filtering the just-added entry out of view.
+    const textarea = screen.getByTestId("manage-modal-textarea");
+    fireEvent.change(textarea, { target: { value: "@beta.com" } });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.add_button"
+      })
+    );
+
+    // The search input must be cleared immediately after the click (no waiting).
+    expect(screen.getByTestId("manage-modal-search")).toHaveValue("");
+
+    // After the debounce window drains (it should be a no-op now that
+    // searchInput was cleared), both entries must be visible.
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+          /manage-modal-row-/
+        )
+      ).toHaveLength(2)
+    );
+  });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -223,6 +223,22 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
   it("Type filter narrows by entry type and composes with search", async () => {
     openModal(["@acme.com", ".edu", "user@acme.com"]);
 
+    // Apply search first and wait for the debounce to actually fire — observable
+    // as a row-count drop from 3 to 2 (".edu" is excluded). This guarantees
+    // `search` has settled before the type filter is exercised, so the later
+    // assertions are not racing the 150 ms debounce.
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+          /manage-modal-row-/
+        )
+      ).toHaveLength(2)
+    );
+
+    // @domain ∩ "acme" → only @acme.com
     fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
       target: { value: "at_domain" }
     });
@@ -232,17 +248,7 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
       )
     ).toHaveLength(1);
 
-    fireEvent.change(screen.getByTestId("manage-modal-search"), {
-      target: { value: "acme" }
-    });
-    await waitFor(() =>
-      expect(
-        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
-          /manage-modal-row-/
-        )
-      ).toHaveLength(1)
-    );
-
+    // .tld ∩ "acme" → nothing (".edu" is a tld but does not match "acme")
     fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
       target: { value: "tld" }
     });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitFor
+} from "@testing-library/react";
 import ManageAllowedEmailDomainsModal from "../ManageAllowedEmailDomainsModal";
 
 // Mock react-window — jsdom has no layout, so FixedSizeList won't render rows.
@@ -154,5 +160,28 @@ describe("ManageAllowedEmailDomainsModal — Tier 1", () => {
       screen.getByRole("button", { name: "edit_promocode.manage_modal.done" })
     );
     expect(onApply).toHaveBeenCalledWith(["@a.com"]);
+  });
+});
+
+describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
+  it("Search narrows the visible list (debounced 150 ms)", async () => {
+    openModal(["@acme.com", "@beta.com", "@acmeworld.com"]);
+    expect(
+      within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(3);
+
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+          /manage-modal-row-/
+        )
+      ).toHaveLength(2)
+    );
   });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -415,51 +415,54 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
   });
 
   it("closing the modal within the debounce window cancels the pending setSearch", () => {
-    // The modal is mounted but hidden (`show={false}`) — the component stays
-    // mounted per AllowedEmailDomainsRow's unconditional render, but the effect
-    // must not fire setSearch while hidden.
+    // Mount visible, type into search to start the debounce clock, then close
+    // (`show={false}`) before 150 ms elapses. The `if (!show) return undefined`
+    // guard must prevent the pending setSearch from firing while hidden.
+    // try/finally guarantees jest.useRealTimers() runs even if an assertion throws.
     jest.useFakeTimers();
-    const { rerender } = render(
-      <ManageAllowedEmailDomainsModal
-        show
-        onHide={onHide}
-        onApply={onApply}
-        existing={["@a.com"]}
-      />
-    );
+    try {
+      const { rerender } = render(
+        <ManageAllowedEmailDomainsModal
+          show
+          onHide={onHide}
+          onApply={onApply}
+          existing={["@a.com"]}
+        />
+      );
 
-    // Type into search — searchInput="acme", debounce clock starts.
-    fireEvent.change(screen.getByTestId("manage-modal-search"), {
-      target: { value: "acme" }
-    });
-    // Verify the input is set before closing.
-    expect(screen.getByTestId("manage-modal-search")).toHaveValue("acme");
+      // Type into search — searchInput="acme", debounce clock starts.
+      fireEvent.change(screen.getByTestId("manage-modal-search"), {
+        target: { value: "acme" }
+      });
+      // Verify the input is set before closing.
+      expect(screen.getByTestId("manage-modal-search")).toHaveValue("acme");
 
-    // Close the modal before 150 ms elapses.
-    rerender(
-      <ManageAllowedEmailDomainsModal
-        show={false}
-        onHide={onHide}
-        onApply={onApply}
-        existing={["@a.com"]}
-      />
-    );
+      // Close the modal before 150 ms elapses.
+      rerender(
+        <ManageAllowedEmailDomainsModal
+          show={false}
+          onHide={onHide}
+          onApply={onApply}
+          existing={["@a.com"]}
+        />
+      );
 
-    // Advance past the debounce window. The `if (!show) return undefined` guard
-    // must prevent setSearch from running (no error, no state update side-effects).
-    expect(() => jest.runAllTimers()).not.toThrow();
+      // Advance past the debounce window. The `if (!show) return undefined`
+      // guard must prevent setSearch from running (no error, no side-effects).
+      expect(() => jest.runAllTimers()).not.toThrow();
 
-    // Reopen the modal — the open effect resets searchInput to "" and search to "".
-    rerender(
-      <ManageAllowedEmailDomainsModal
-        show
-        onHide={onHide}
-        onApply={onApply}
-        existing={["@a.com"]}
-      />
-    );
-    expect(screen.getByTestId("manage-modal-search")).toHaveValue("");
-
-    jest.useRealTimers();
+      // Reopen the modal — the open effect resets searchInput and search to "".
+      rerender(
+        <ManageAllowedEmailDomainsModal
+          show
+          onHide={onHide}
+          onApply={onApply}
+          existing={["@a.com"]}
+        />
+      );
+      expect(screen.getByTestId("manage-modal-search")).toHaveValue("");
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -219,4 +219,65 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
       ).toHaveLength(2)
     );
   });
+
+  it("Type filter narrows by entry type and composes with search", async () => {
+    openModal(["@acme.com", ".edu", "user@acme.com"]);
+
+    fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
+      target: { value: "at_domain" }
+    });
+    expect(
+      within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(1);
+
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+          /manage-modal-row-/
+        )
+      ).toHaveLength(1)
+    );
+
+    fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
+      target: { value: "tld" }
+    });
+    expect(
+      within(screen.getByTestId("fixed-size-list")).queryAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(0);
+  });
+
+  it("Add Domains while filtered clears the filter so additions are visible", () => {
+    openModal(["@acme.com"]);
+    fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
+      target: { value: "tld" }
+    });
+    // .tld filter hides @acme.com
+    expect(
+      within(screen.getByTestId("fixed-size-list")).queryAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(0);
+    fireEvent.change(screen.getByTestId("manage-modal-textarea"), {
+      target: { value: "@beta.com" }
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.add_button"
+      })
+    );
+    // filter reset to "all" → both the pre-existing and the new entry show
+    expect(screen.getByTestId("manage-modal-type-filter")).toHaveValue("all");
+    expect(
+      within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(2);
+  });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -8,10 +8,22 @@ import {
 } from "@testing-library/react";
 import ManageAllowedEmailDomainsModal from "../ManageAllowedEmailDomainsModal";
 
+// Shared scroll-call log written by the react-window mock below.
+// Tests clear this in beforeEach; the mock pushes { index, itemCountAtCallTime }
+// on every scrollToItem call so deferred-scroll tests can inspect call-time state.
+const scrollLog = [];
+
 // Mock react-window — jsdom has no layout, so FixedSizeList won't render rows.
 // Mock renders first 10 rows directly to match production's ~10-rows-visible cap.
+//
+// On every render the mock closes over the current `itemCount` so that
+// scrollToItem records itemCountAtCallTime — distinguishing whether the call
+// happened before or after the list re-rendered with the new (larger) count.
 jest.mock("react-window", () => {
   const React = require("react");
+  // Reference the module-level scrollLog declared above (same module scope).
+  // jest.mock hoists, but the factory runs lazily, so by the time it executes
+  // scrollLog is already defined.
   return {
     __esModule: true,
     FixedSizeList: React.forwardRef(
@@ -19,7 +31,13 @@ jest.mock("react-window", () => {
         const Row = children;
         const visible = Math.min(itemCount, 10);
         if (ref) {
-          ref.current = { scrollToItem: jest.fn() };
+          ref.current = {
+            scrollToItem: jest.fn((index, align) => {
+              // scrollLog is closed over from the outer module scope.
+              // itemCount here is the value from THIS render cycle.
+              scrollLog.push({ index, align, itemCountAtCallTime: itemCount });
+            })
+          };
         }
         return React.createElement(
           "div",
@@ -44,6 +62,7 @@ const onHide = jest.fn();
 beforeEach(() => {
   onApply.mockClear();
   onHide.mockClear();
+  scrollLog.length = 0;
 });
 
 const openModal = (existing = []) =>
@@ -356,5 +375,42 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
       })
     );
     expect(onApply).toHaveBeenCalledWith(["@acme.com", "@beta.com"]);
+  });
+
+  it("autoscroll after Add targets the new last index with the post-add itemCount", async () => {
+    // Open with 2 entries. Add 1 more (new total: 3).
+    // The deferred-scroll fix: scrollToItem must be called with index=2 AND
+    // itemCountAtCallTime=3 (not the pre-add itemCount of 2). The pre-fix
+    // synchronous code would call scrollToItem while the list still had
+    // itemCount=2, clamping the scroll target to index 1 (the old last row).
+    //
+    // What this test DOES verify: scrollToItem is called once, with the correct
+    // index (visible.length - 1 = 2) and the correct itemCount at call time (3).
+    //
+    // What this test does NOT verify: that the scroll actually moves the browser
+    // viewport — jsdom has no layout engine, so the scrollToItem call is captured
+    // via the mock but never produces a visual scroll. The test validates the
+    // index + call-time itemCount contract, not the pixel position.
+    openModal(["@a.com", "@b.com"]);
+    expect(scrollLog).toHaveLength(0);
+
+    const textarea = screen.getByTestId("manage-modal-textarea");
+    fireEvent.change(textarea, { target: { value: "@c.com" } });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.add_button"
+      })
+    );
+
+    // The deferred effect fires after React commits the new visible array.
+    // waitFor lets RTL flush all state updates + effects.
+    await waitFor(() => expect(scrollLog).toHaveLength(1));
+
+    const [call] = scrollLog;
+    // Index must target the new last row (3 entries → index 2).
+    expect(call.index).toBe(2);
+    // itemCountAtCallTime must equal the post-add count (3), proving the effect
+    // ran after the list re-rendered — not synchronously while itemCount was 2.
+    expect(call.itemCountAtCallTime).toBe(3);
   });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -317,7 +317,10 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
   });
 
   it("Select All respects the active filter (only visible rows deleted)", () => {
-    openModal(["@acme.com", ".edu", "user@acme.com"]);
+    // Indices chosen so the filtered rows' originalIndex (1, 3) differ from
+    // their visible indices (0, 1): a buggy impl selecting by visible index
+    // would delete the wrong working entries and fail this assertion.
+    openModal([".edu", "@acme.com", "user@acme.com", "@beta.com"]);
     fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
       target: { value: "at_domain" }
     });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -413,4 +413,53 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
     // ran after the list re-rendered — not synchronously while itemCount was 2.
     expect(call.itemCountAtCallTime).toBe(3);
   });
+
+  it("closing the modal within the debounce window cancels the pending setSearch", () => {
+    // The modal is mounted but hidden (`show={false}`) — the component stays
+    // mounted per AllowedEmailDomainsRow's unconditional render, but the effect
+    // must not fire setSearch while hidden.
+    jest.useFakeTimers();
+    const { rerender } = render(
+      <ManageAllowedEmailDomainsModal
+        show
+        onHide={onHide}
+        onApply={onApply}
+        existing={["@a.com"]}
+      />
+    );
+
+    // Type into search — searchInput="acme", debounce clock starts.
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+    // Verify the input is set before closing.
+    expect(screen.getByTestId("manage-modal-search")).toHaveValue("acme");
+
+    // Close the modal before 150 ms elapses.
+    rerender(
+      <ManageAllowedEmailDomainsModal
+        show={false}
+        onHide={onHide}
+        onApply={onApply}
+        existing={["@a.com"]}
+      />
+    );
+
+    // Advance past the debounce window. The `if (!show) return undefined` guard
+    // must prevent setSearch from running (no error, no state update side-effects).
+    expect(() => jest.runAllTimers()).not.toThrow();
+
+    // Reopen the modal — the open effect resets searchInput to "" and search to "".
+    rerender(
+      <ManageAllowedEmailDomainsModal
+        show
+        onHide={onHide}
+        onApply={onApply}
+        existing={["@a.com"]}
+      />
+    );
+    expect(screen.getByTestId("manage-modal-search")).toHaveValue("");
+
+    jest.useRealTimers();
+  });
 });

--- a/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
+++ b/src/components/forms/promocode-form/forms/domain-authorized/__tests__/manage-modal.test.jsx
@@ -286,4 +286,72 @@ describe("ManageAllowedEmailDomainsModal — Tier 2", () => {
       )
     ).toHaveLength(2);
   });
+
+  it("single checkbox + Delete Selected removes only that entry", () => {
+    openModal(["@a.com", "@b.com", "@c.com"]);
+    fireEvent.click(screen.getByTestId("manage-modal-checkbox-1"));
+    fireEvent.click(screen.getByTestId("manage-modal-delete-selected"));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.done"
+      })
+    );
+    expect(onApply).toHaveBeenCalledWith(["@a.com", "@c.com"]);
+  });
+
+  it("Select All + Delete Selected empties the working list", () => {
+    openModal(["@a.com", "@b.com", "@c.com"]);
+    fireEvent.click(screen.getByTestId("manage-modal-select-all"));
+    fireEvent.click(screen.getByTestId("manage-modal-delete-selected"));
+    expect(
+      within(screen.getByTestId("fixed-size-list")).queryAllByTestId(
+        /manage-modal-row-/
+      )
+    ).toHaveLength(0);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.done"
+      })
+    );
+    expect(onApply).toHaveBeenCalledWith([]);
+  });
+
+  it("Select All respects the active filter (only visible rows deleted)", () => {
+    openModal(["@acme.com", ".edu", "user@acme.com"]);
+    fireEvent.change(screen.getByTestId("manage-modal-type-filter"), {
+      target: { value: "at_domain" }
+    });
+    fireEvent.click(screen.getByTestId("manage-modal-select-all"));
+    fireEvent.click(screen.getByTestId("manage-modal-delete-selected"));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.done"
+      })
+    );
+    expect(onApply).toHaveBeenCalledWith([".edu", "user@acme.com"]);
+  });
+
+  it("selection clears when search changes", async () => {
+    openModal(["@acme.com", "@beta.com"]);
+    fireEvent.click(screen.getByTestId("manage-modal-checkbox-0"));
+    fireEvent.change(screen.getByTestId("manage-modal-search"), {
+      target: { value: "acme" }
+    });
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId("fixed-size-list")).getAllByTestId(
+          /manage-modal-row-/
+        )
+      ).toHaveLength(1)
+    );
+    // Direct invariant: with selection cleared, Delete Selected is disabled.
+    expect(screen.getByTestId("manage-modal-delete-selected")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("manage-modal-delete-selected"));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "edit_promocode.manage_modal.done"
+      })
+    );
+    expect(onApply).toHaveBeenCalledWith(["@acme.com", "@beta.com"]);
+  });
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1052,6 +1052,12 @@
       "added_toast": "Added {added} · skipped {invalid} invalid · {dup} duplicates",
       "configured_count": "Configured Domains ({n})",
       "search_placeholder": "Search domains...",
+      "filter": {
+        "all": "All",
+        "at_domain": "@domain",
+        "tld": ".tld",
+        "email": "user@email"
+      },
       "done": "Done",
       "cancel": "Cancel"
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1051,6 +1051,7 @@
       "add_button": "Add Domains",
       "added_toast": "Added {added} · skipped {invalid} invalid · {dup} duplicates",
       "configured_count": "Configured Domains ({n})",
+      "search_placeholder": "Search domains...",
       "done": "Done",
       "cancel": "Cancel"
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1052,6 +1052,10 @@
       "added_toast": "Added {added} · skipped {invalid} invalid · {dup} duplicates",
       "configured_count": "Configured Domains ({n})",
       "search_placeholder": "Search domains...",
+      "search_aria": "Search domains",
+      "type_filter_aria": "Filter domains by type",
+      "add_aria": "Add allowed email domains",
+      "row_select_aria": "Select {entry}",
       "filter": {
         "all": "All",
         "at_domain": "@domain",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1058,6 +1058,8 @@
         "tld": ".tld",
         "email": "user@email"
       },
+      "select_all": "Select All",
+      "delete_selected": "Delete Selected ({n})",
       "done": "Done",
       "cancel": "Cancel"
     },


### PR DESCRIPTION
ref: https://app.clickup.com/t/86ba1pt2t

## Domain-Authorized Promo Codes — Bulk Input Tier 2

Extends `ManageAllowedEmailDomainsModal` so admins can find and remove entries
within a large `allowed_email_domains` list. Pure frontend — no API change, the
`allowed_email_domains: string[]` wire contract is untouched. Independent of the
summit-api Track 2 work.

### What's new

- **In-modal search** — substring match, debounced 150 ms.
- **Type filter** — `All` / `@domain` / `.tld` / `user@email`; composes with search.
- **Multi-select delete** — per-row checkbox, Select All (scoped to the filtered
  view), and Delete Selected.

Tier 1 shipped the modal with a read-only virtualized list; Tier 2 adds three
modal-scoped state slices (debounced search, type filter, a selection `Set`
keyed by original array index). A `visible` memo derives the filtered view,
carrying `originalIndex` so selection and deletion stay correct under filtering.

### Implementation notes

Built task-by-task with per-task spec + code-quality review and a Codex review
pass after each task, plus a whole-branch Codex pass. Review-driven fixes folded
in: deferred post-add autoscroll (react-window had the stale `itemCount` when
`scrollToItem` ran synchronously after a batched `setWorking`), a debounce-window
race on Add, removal of an out-of-scope search-flush, the search debounce effect
gated on modal `show`, and a strengthened filtered-Select-All test that guards
the `originalIndex` contract.

### Testing

- **Automated:** 17 modal tests (`manage-modal.test.jsx`); full
  `promocode-form` suite green (121); 0 ESLint errors.
- **Manual — component harness:** mounted the real modal with 63 synthetic
  domains and drove it in a browser — search narrowing, type filter + search
  composition, multi-select delete, autoscroll-on-add, filtered-add-clears-filter,
  Done/Cancel. No console errors.
- **Manual — full app:** end-to-end against `api.dev.fnopen.com` — opened a
  `DOMAIN_AUTHORIZED_*` promo code, exercised search / type filter / multi-select
  delete, Saved, reloaded, and confirmed the persisted `allowed_email_domains`
  round-trips correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality with debouncing to filter email domains in the management modal.
  * Added type filter (domain/TLD/email) for refined domain list browsing.
  * Added "Select All" and "Delete Selected" bulk actions for managing domains.
  * Improved filter auto-reset behavior when adding new domains.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->