### PR TITLE
fix: adjust validation and payload for sponsor settings

### DIFF
--- a/src/actions/sponsor-settings-actions.js
+++ b/src/actions/sponsor-settings-actions.js
@@ -177,18 +177,30 @@ const normalizeEntityFprPurchaseAPI = (entity, summitTZ) => {
 
   normalizedEntity.wire_transfer_notification_email =
     wire_transfer_notification_email?.split(";") || [];
-  normalizedEntity.early_bird_end_date = moment
-    .tz(early_bird_end_date, summitTZ)
-    .unix();
-  normalizedEntity.standard_price_end_date = moment
-    .tz(standard_price_end_date, summitTZ)
-    .unix();
-  normalizedEntity.onsite_price_start_date = moment
-    .tz(onsite_price_start_date, summitTZ)
-    .unix();
-  normalizedEntity.onsite_price_end_date = moment
-    .tz(onsite_price_end_date, summitTZ)
-    .unix();
+
+  if (early_bird_end_date)
+    normalizedEntity.early_bird_end_date = moment
+      .tz(early_bird_end_date, summitTZ)
+      .unix();
+  else delete normalizedEntity.early_bird_end_date;
+
+  if (standard_price_end_date)
+    normalizedEntity.standard_price_end_date = moment
+      .tz(standard_price_end_date, summitTZ)
+      .unix();
+  else delete normalizedEntity.standard_price_end_date;
+
+  if (onsite_price_start_date)
+    normalizedEntity.onsite_price_start_date = moment
+      .tz(onsite_price_start_date, summitTZ)
+      .unix();
+  else delete normalizedEntity.onsite_price_start_date;
+
+  if (onsite_price_end_date)
+    normalizedEntity.onsite_price_end_date = moment
+      .tz(onsite_price_end_date, summitTZ)
+      .unix();
+  else delete normalizedEntity.onsite_price_end_date;
 
   return normalizedEntity;
 };

--- a/src/components/forms/sponsor-settings-form/index.js
+++ b/src/components/forms/sponsor-settings-form/index.js
@@ -58,9 +58,10 @@ const SponsorSettingsForm = ({ settings, onSubmit, summitTZ }) => {
   const formik = useFormik({
     initialValues: buildInitialValues(settings, summitTZ),
     validationSchema: yup.object({
-      early_bird_end_date: yup.date(T.translate("validation.date")),
+      early_bird_end_date: yup.date(T.translate("validation.date")).nullable(),
       standard_price_end_date: yup
         .date(T.translate("validation.date"))
+        .nullable()
         .isAfterDateField(
           yup.ref("early_bird_end_date"),
           T.translate("validation.after", {
@@ -70,6 +71,7 @@ const SponsorSettingsForm = ({ settings, onSubmit, summitTZ }) => {
         ),
       onsite_price_start_date: yup
         .date(T.translate("validation.date"))
+        .nullable()
         .isAfterDateField(
           yup.ref("standard_price_end_date"),
           T.translate("validation.after", {
@@ -79,6 +81,7 @@ const SponsorSettingsForm = ({ settings, onSubmit, summitTZ }) => {
         ),
       onsite_price_end_date: yup
         .date(T.translate("validation.date"))
+        .nullable()
         .isAfterDateField(
           yup.ref("onsite_price_start_date"),
           T.translate("validation.after", {


### PR DESCRIPTION
ref: https://app.clickup.com/t/86ba492b2

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed sponsor settings form validation. Date fields (early bird end date, standard price end date, onsite price dates) are now optional instead of required, allowing users to leave these fields empty. The system properly handles missing values without generating unwanted timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fntechgit/summit-admin/pull/955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->