### PR TITLE
fix: add missing perPage param on sponsor forms tables, adjust names

### DIFF
--- a/src/actions/__tests__/sponsor-forms-actions.test.js
+++ b/src/actions/__tests__/sponsor-forms-actions.test.js
@@ -83,7 +83,7 @@ describe("Sponsor Forms Actions", () => {
             showArchived: false,
             order: "id",
             orderDir: 1,
-            currentPage: 2,
+            page: 2,
             perPage: 50,
             term: ""
           }
@@ -198,6 +198,7 @@ describe("Sponsor Forms Actions", () => {
 
     beforeEach(() => {
       jest.spyOn(methods, "getAccessTokenSafely").mockReturnValue("TOKEN");
+      getRequest.mockClear();
 
       putRequest.mockImplementation((...requestArgs) => {
         const [, receiveActionCreator] = requestArgs;
@@ -280,7 +281,7 @@ describe("Sponsor Forms Actions", () => {
           showArchived: false,
           order: "name",
           orderDir: -1,
-          currentPage: 3,
+          page: 3,
           perPage: 25,
           term: "expo"
         }

--- a/src/actions/sponsor-forms-actions.js
+++ b/src/actions/sponsor-forms-actions.js
@@ -111,7 +111,7 @@ export const SPONSOR_FORM_ITEM_UNARCHIVED = "SPONSOR_FORM_ITEM_UNARCHIVED";
 export const getSponsorForms =
   (
     term = "",
-    currentPage = DEFAULT_CURRENT_PAGE,
+    page = DEFAULT_CURRENT_PAGE,
     perPage = DEFAULT_PER_PAGE,
     order = "id",
     orderDir = DEFAULT_ORDER_DIR,
@@ -132,7 +132,7 @@ export const getSponsorForms =
     }
 
     const params = {
-      page: currentPage,
+      page,
       fields:
         "id,code,name,level,expire_date,is_archived,sponsorship_types,apply_to_all_types,opens_at,expires_at",
       relations: "items,sponsorship_types",
@@ -164,7 +164,7 @@ export const getSponsorForms =
       createAction(RECEIVE_SPONSOR_FORMS),
       `${window.PURCHASES_API_URL}/api/v1/summits/${currentSummit.id}/show-forms`,
       authErrorHandler,
-      { order, orderDir, currentPage, perPage, term, showArchived }
+      { order, orderDir, page, perPage, term, showArchived }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });
@@ -552,7 +552,7 @@ export const getSponsorManagedForms =
       createAction(RECEIVE_SPONSOR_MANAGED_FORMS),
       `${window.PURCHASES_API_URL}/api/v1/summits/${currentSummit.id}/sponsors/${sponsorId}/managed-forms`,
       authErrorHandler,
-      { order, orderDir, page, term, summitTZ, showArchived }
+      { order, orderDir, page, perPage, term, summitTZ, showArchived }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });
@@ -720,7 +720,7 @@ export const getSponsorCustomizedForms =
       createAction(RECEIVE_SPONSOR_CUSTOMIZED_FORMS),
       `${window.PURCHASES_API_URL}/api/v1/summits/${currentSummit.id}/sponsors/${sponsorId}/sponsor-forms`,
       authErrorHandler,
-      { order, orderDir, page, term, summitTZ, showArchived }
+      { order, orderDir, page, perPage, term, summitTZ, showArchived }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });

--- a/src/pages/sponsors/show-pages-list-page/index.js
+++ b/src/pages/sponsors/show-pages-list-page/index.js
@@ -77,7 +77,14 @@ const ShowPagesListPage = ({
   };
 
   const handlePerPageChange = (newPerPage) => {
-    getShowPages(term, currentPage, newPerPage, order, orderDir, showArchived);
+    getShowPages(
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir,
+      showArchived
+    );
   };
 
   const handleRowDelete = (itemId) => {

--- a/src/reducers/sponsors/sponsor-page-forms-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-page-forms-list-reducer.js
@@ -58,7 +58,8 @@ const sponsorPageFormsListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_SPONSOR_MANAGED_FORMS: {
-      const { order, orderDir, page, term, summitTZ, showArchived } = payload;
+      const { order, orderDir, page, perPage, term, summitTZ, showArchived } =
+        payload;
 
       return {
         ...state,
@@ -67,7 +68,8 @@ const sponsorPageFormsListReducer = (state = DEFAULT_STATE, action) => {
           order,
           orderDir,
           forms: [],
-          currentPage: page
+          currentPage: page,
+          perPage
         },
         term,
         summitTZ,
@@ -75,7 +77,8 @@ const sponsorPageFormsListReducer = (state = DEFAULT_STATE, action) => {
       };
     }
     case REQUEST_SPONSOR_CUSTOMIZED_FORMS: {
-      const { order, orderDir, page, term, summitTZ, showArchived } = payload;
+      const { order, orderDir, page, perPage, term, summitTZ, showArchived } =
+        payload;
 
       return {
         ...state,
@@ -84,7 +87,8 @@ const sponsorPageFormsListReducer = (state = DEFAULT_STATE, action) => {
           order,
           orderDir,
           forms: [],
-          currentPage: page
+          currentPage: page,
+          perPage
         },
         term,
         summitTZ,


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bact0p7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced pagination for sponsor forms: the page parameter is used consistently, items-per-page is tracked, and changing items-per-page resets to the first page.
* **Tests**
  * Updated tests to reflect the pagination parameter rename and to reset request mock state before specific refetch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->