### PR TITLE
fix: add missing instruction field on sponsor managed forms

### DIFF
--- a/src/actions/sponsor-forms-actions.js
+++ b/src/actions/sponsor-forms-actions.js
@@ -648,7 +648,7 @@ export const getSponsorManagedForm = (formId) => async (dispatch, getState) => {
 
   const params = {
     fields:
-      "id,code,name,is_archived,opens_at,expires_at,items_count,allowed_add_ons",
+      "id,code,name,is_archived,opens_at,expires_at,items_count,allowed_add_ons,instructions",
     expand:
       "allowed_add_ons,meta_fields,meta_fields.values,items,items.meta_fields,items.meta_fields.values,items.images",
     access_token: accessToken


### PR DESCRIPTION
ref: https://app.clickup.com/t/86baayr5u

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sponsor-managed forms now include instruction content when fetching form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->