### PR TITLE
fix: add customized label on sponsor customized forms

### DIFF
--- a/src/actions/sponsor-forms-actions.js
+++ b/src/actions/sponsor-forms-actions.js
@@ -697,7 +697,7 @@ export const getSponsorCustomizedForms =
     const params = {
       page,
       fields:
-        "id,code,name,is_archived,opens_at,expires_at,items_count,allowed_add_ons",
+        "id,code,name,is_archived,opens_at,expires_at,items_count,allowed_add_ons,original_show_form_id",
       expands: "allowed_add_ons",
       per_page: perPage,
       access_token: accessToken

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2499,6 +2499,7 @@
       "unarchive": "Unarchive",
       "add_form_using_template": "Add Form Using Template",
       "add_selected_form_template": "Add Selected Form Template",
+      "customized": "CUSTOMIZED",
       "customized_form": {
         "new_form_title": "Create New Form",
         "edit_form_title": "Edit Form",

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/index.js
@@ -18,6 +18,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Chip,
   FormControlLabel,
   FormGroup,
   Grid2
@@ -261,7 +262,19 @@ const SponsorFormsTab = ({
       columnKey: "name",
       header: name,
       sortable: true,
-      width: 235
+      width: 235,
+      render: (row) =>
+        row.original_show_form_id > 0 ? (
+          <>
+            {row.name}&nbsp;
+            <Chip
+              size="small"
+              label={T.translate("edit_sponsor.forms_tab.customized")}
+            />
+          </>
+        ) : (
+          row.name
+        )
     },
     {
       columnKey: "code",

--- a/src/reducers/sponsors/sponsor-page-forms-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-page-forms-list-reducer.js
@@ -160,7 +160,8 @@ const sponsorPageFormsListReducer = (state = DEFAULT_STATE, action) => {
           allowed_add_ons: a.allowed_add_ons,
           is_archived: a.is_archived,
           opens_at: opensAt,
-          expires_at: expiresAt
+          expires_at: expiresAt,
+          original_show_form_id: a.original_show_form_id
         };
       });
 


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bad7927

<img width="1222" height="798" alt="image" src="https://github.com/user-attachments/assets/7f9cf975-9205-4741-add9-850f4e885ea5" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forms in the sponsor forms tab now display a visual "customized" indicator for customized forms, making them easier to distinguish at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->