### PR TITLE
feat: move event category groups to mui

### DIFF
--- a/src/actions/event-category-actions.js
+++ b/src/actions/event-category-actions.js
@@ -21,12 +21,16 @@ import {
   startLoading,
   showMessage,
   showSuccessMessage,
-  authErrorHandler
+  authErrorHandler,
+  escapeFilterValue
 } from "openstack-uicore-foundation/lib/utils/actions";
 import T from "i18n-react/dist/i18n-react";
 import history from "../history";
 import { getAccessTokenSafely } from "../utils/methods";
-import { HUNDRED_PER_PAGE } from "../utils/constants";
+import {
+  DEFAULT_PER_PAGE,
+  DEFAULT_CURRENT_PAGE
+} from "../utils/constants";
 
 export const REQUEST_EVENT_CATEGORIES = "REQUEST_EVENT_CATEGORIES";
 export const RECEIVE_EVENT_CATEGORIES = "RECEIVE_EVENT_CATEGORIES";
@@ -380,31 +384,55 @@ const normalizeEntity = (entity) => {
 
 /** *********************************  CATEGORY GROUPS ************************************************** */
 
-export const getEventCategoryGroups = () => async (dispatch, getState) => {
-  const { currentSummitState } = getState();
-  const accessToken = await getAccessTokenSafely();
-  const { currentSummit } = currentSummitState;
+export const getEventCategoryGroups =
+  (
+    term = null,
+    page = DEFAULT_CURRENT_PAGE,
+    perPage = DEFAULT_PER_PAGE,
+    order = "id",
+    orderDir = 1
+  ) =>
+  async (dispatch, getState) => {
+    const { currentSummitState } = getState();
+    const accessToken = await getAccessTokenSafely();
+    const { currentSummit } = currentSummitState;
+    const filter = [];
 
-  dispatch(startLoading());
+    dispatch(startLoading());
 
-  const params = {
-    access_token: accessToken,
-    page: 1,
-    per_page: HUNDRED_PER_PAGE,
-    expand: "tracks",
-    fields: "id,name,class_name,color,tracks.name,tracks.id",
-    relations: "tracks.none"
+    const params = {
+      access_token: accessToken,
+      page,
+      per_page: perPage,
+      expand: "tracks",
+      fields: "id,name,class_name,color,tracks.name,tracks.id",
+      relations: "tracks.none"
+    };
+
+    if (term) {
+      const escapedTerm = escapeFilterValue(term);
+      filter.push(`name=@${escapedTerm}`);
+    }
+
+    if (filter.length > 0) {
+      params["filter[]"] = filter;
+    }
+
+    if (order != null && orderDir != null) {
+      const orderDirSign = orderDir === 1 ? "" : "-";
+      params.order = `${orderDirSign}${order}`;
+    }
+
+    return getRequest(
+      createAction(REQUEST_EVENT_CATEGORY_GROUPS),
+      createAction(RECEIVE_EVENT_CATEGORY_GROUPS),
+      `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-groups`,
+      authErrorHandler,
+      { order, orderDir, term, perPage }
+    )(params)(dispatch).then(() => {
+      dispatch(stopLoading());
+    });
   };
-
-  return getRequest(
-    createAction(REQUEST_EVENT_CATEGORY_GROUPS),
-    createAction(RECEIVE_EVENT_CATEGORY_GROUPS),
-    `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-groups`,
-    authErrorHandler
-  )(params)(dispatch).then(() => {
-    dispatch(stopLoading());
-  });
-};
 
 export const getEventCategoryGroup =
   (groupId) => async (dispatch, getState) => {

--- a/src/actions/event-category-actions.js
+++ b/src/actions/event-category-actions.js
@@ -27,10 +27,7 @@ import {
 import T from "i18n-react/dist/i18n-react";
 import history from "../history";
 import { getAccessTokenSafely } from "../utils/methods";
-import {
-  DEFAULT_PER_PAGE,
-  DEFAULT_CURRENT_PAGE
-} from "../utils/constants";
+import { DEFAULT_PER_PAGE, DEFAULT_CURRENT_PAGE } from "../utils/constants";
 
 export const REQUEST_EVENT_CATEGORIES = "REQUEST_EVENT_CATEGORIES";
 export const RECEIVE_EVENT_CATEGORIES = "RECEIVE_EVENT_CATEGORIES";
@@ -428,7 +425,7 @@ export const getEventCategoryGroups =
       createAction(RECEIVE_EVENT_CATEGORY_GROUPS),
       `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/track-groups`,
       authErrorHandler,
-      { order, orderDir, term, perPage }
+      { order, orderDir, term, perPage, currentPage: page }
     )(params)(dispatch).then(() => {
       dispatch(stopLoading());
     });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1390,7 +1390,7 @@
     "type": "Type",
     "categories": "Categories",
     "color": "Color",
-    "delete_warning": "Please verify you want to delete activity category group "
+    "delete_warning": "Please verify you want to delete activity category group"
   },
   "edit_event_category_group": {
     "event_category_group": "Activity Category Group",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1382,15 +1382,15 @@
     }
   },
   "event_category_group_list": {
-    "event_category_group_list": "Activity Category Groups",
-    "event_category_groups": "Activity Category Groups",
+    "event_category_group_list": "Activity Category Groups List",
+    "event_category_groups": "Groups",
     "no_items": "No activity category groups found.",
     "add_category_group": "Add Group",
     "name": "Name",
     "type": "Type",
     "categories": "Categories",
     "color": "Color",
-    "delete_warning": "Are you sure you want to delete activity category group "
+    "delete_warning": "Please verify you want to delete activity category group "
   },
   "edit_event_category_group": {
     "event_category_group": "Activity Category Group",

--- a/src/pages/events/event-category-group-list-page.js
+++ b/src/pages/events/event-category-group-list-page.js
@@ -40,10 +40,10 @@ const EventCategoryGroupListPage = ({
   history
 }) => {
   useEffect(() => {
-    if (currentSummit) {
+    if (currentSummit?.id) {
       getEventCategoryGroups();
     }
-  }, []);
+  }, [currentSummit?.id]);
 
   const handleEdit = (row) => {
     history.push(

--- a/src/pages/events/event-category-group-list-page.js
+++ b/src/pages/events/event-category-group-list-page.js
@@ -11,129 +11,201 @@
  * limitations under the License.
  * */
 
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import T from "i18n-react/dist/i18n-react";
-import Swal from "sweetalert2";
-import Table from "openstack-uicore-foundation/lib/components/table";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid2 from "@mui/material/Grid2";
+import AddIcon from "@mui/icons-material/Add";
+import MuiTable from "openstack-uicore-foundation/lib/components/mui/table";
+import SearchInput from "openstack-uicore-foundation/lib/components/mui/search-input";
 import {
   getEventCategoryGroups,
   deleteEventCategoryGroup
 } from "../../actions/event-category-actions";
+import { DEFAULT_CURRENT_PAGE } from "../../utils/constants";
 
-class EventCategoryGroupListPage extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.handleEdit = this.handleEdit.bind(this);
-    this.handleNew = this.handleNew.bind(this);
-    this.handleDelete = this.handleDelete.bind(this);
-  }
-
-  componentDidMount() {
-    const { currentSummit } = this.props;
+const EventCategoryGroupListPage = ({
+  currentSummit,
+  eventCategoryGroups,
+  term,
+  currentPage,
+  perPage,
+  order,
+  orderDir,
+  totalEventCategoryGroups,
+  getEventCategoryGroups,
+  deleteEventCategoryGroup,
+  history
+}) => {
+  useEffect(() => {
     if (currentSummit) {
-      this.props.getEventCategoryGroups();
+      getEventCategoryGroups();
     }
-  }
+  }, []);
 
-  handleEdit(groupId) {
-    const { currentSummit, history } = this.props;
+  const handleEdit = (row) => {
     history.push(
-      `/app/summits/${currentSummit.id}/event-category-groups/${groupId}`
+      `/app/summits/${currentSummit.id}/event-category-groups/${row.id}`
     );
-  }
+  };
 
-  handleNew() {
-    const { currentSummit, history } = this.props;
+  const handleNew = () => {
     history.push(`/app/summits/${currentSummit.id}/event-category-groups/new`);
-  }
+  };
 
-  handleDelete(groupId) {
-    const { deleteEventCategoryGroup, eventCategoryGroups } = this.props;
-    const group = eventCategoryGroups.find((g) => g.id === groupId);
-
-    Swal.fire({
-      title: T.translate("general.are_you_sure"),
-      text: `${T.translate("event_category_group_list.delete_warning")} ${
-        group.name
-      }`,
-      type: "warning",
-      showCancelButton: true,
-      confirmButtonColor: "#DD6B55",
-      confirmButtonText: T.translate("general.yes_delete")
-    }).then((result) => {
-      if (result.value) {
-        deleteEventCategoryGroup(groupId);
-      }
-    });
-  }
-
-  render() {
-    const { currentSummit, eventCategoryGroups } = this.props;
-
-    const columns = [
-      { columnKey: "id", value: T.translate("general.id") },
-      {
-        columnKey: "name",
-        value: T.translate("event_category_group_list.name")
-      },
-      {
-        columnKey: "type",
-        value: T.translate("event_category_group_list.type")
-      },
-      {
-        columnKey: "categories",
-        value: T.translate("event_category_group_list.categories")
-      },
-      {
-        columnKey: "color",
-        value: T.translate("event_category_group_list.color")
-      }
-    ];
-
-    const table_options = {
-      actions: {
-        edit: { onClick: this.handleEdit },
-        delete: { onClick: this.handleDelete }
-      }
-    };
-
-    if (!currentSummit.id) return <div />;
-
-    return (
-      <div className="container">
-        <h3> {T.translate("event_category_list.event_category_list")} </h3>
-        <div className="row">
-          <div className="col-md-6 col-md-offset-6 text-right">
-            <button
-              className="btn btn-primary right-space"
-              onClick={this.handleNew}
-            >
-              {T.translate("event_category_group_list.add_category_group")}
-            </button>
-          </div>
-        </div>
-
-        {eventCategoryGroups.length === 0 && (
-          <div className="no-items">
-            {T.translate("event_category_group_list.no_items")}
-          </div>
-        )}
-
-        {eventCategoryGroups.length > 0 && (
-          <div>
-            <Table
-              options={table_options}
-              data={eventCategoryGroups}
-              columns={columns}
-            />
-          </div>
-        )}
-      </div>
+  const handleDelete = (groupId) => {
+    deleteEventCategoryGroup(groupId).then(() =>
+      getEventCategoryGroups(
+        term,
+        DEFAULT_CURRENT_PAGE,
+        perPage,
+        order,
+        orderDir
+      )
     );
-  }
-}
+  };
+
+  const handleSearch = (searchTerm) => {
+    getEventCategoryGroups(
+      searchTerm,
+      DEFAULT_CURRENT_PAGE,
+      perPage,
+      order,
+      orderDir
+    );
+  };
+
+  const handlePageChange = (page) => {
+    getEventCategoryGroups(term, page, perPage, order, orderDir);
+  };
+
+  const handlePerPageChange = (newPerPage) => {
+    getEventCategoryGroups(
+      term,
+      DEFAULT_CURRENT_PAGE,
+      newPerPage,
+      order,
+      orderDir
+    );
+  };
+
+  const handleSort = (key, dir) => {
+    getEventCategoryGroups(term, currentPage, perPage, key, dir);
+  };
+
+  const columns = [
+    {
+      columnKey: "id",
+      header: T.translate("general.id"),
+      width: 60,
+      sortable: true
+    },
+    {
+      columnKey: "name",
+      header: T.translate("event_category_group_list.name"),
+      width: 160,
+      sortable: true
+    },
+    {
+      columnKey: "type",
+      header: T.translate("event_category_group_list.type"),
+      width: 90
+    },
+    {
+      columnKey: "categories",
+      header: T.translate("event_category_group_list.categories")
+    },
+    {
+      columnKey: "color",
+      header: T.translate("event_category_group_list.color"),
+      width: 70,
+      render: (row) => (
+        <Box
+          sx={{
+            width: 24,
+            height: 24,
+            backgroundColor: row.color,
+            borderRadius: 1
+          }}
+        />
+      )
+    }
+  ];
+
+  const tableOptions = { sortCol: order, sortDir: orderDir };
+
+  if (!currentSummit.id) return <div />;
+
+  return (
+    <div className="container">
+      <h3>
+        {T.translate("event_category_group_list.event_category_group_list")}
+      </h3>
+      <Grid2
+        container
+        spacing={1}
+        sx={{ justifyContent: "space-between", alignItems: "center", mb: 2 }}
+      >
+        <Grid2 size={2}>
+          <Box component="span">
+            {totalEventCategoryGroups}{" "}
+            {T.translate("event_category_group_list.event_category_groups")}
+          </Box>
+        </Grid2>
+        <Grid2
+          container
+          size={10}
+          gap={1}
+          sx={{ justifyContent: "flex-end", alignItems: "center" }}
+        >
+          <Grid2 size={4}>
+            <SearchInput term={term} onSearch={handleSearch} />
+          </Grid2>
+          <Button
+            variant="contained"
+            onClick={handleNew}
+            startIcon={<AddIcon />}
+            sx={{
+              height: "36px",
+              padding: "6px 16px",
+              fontSize: "1.4rem",
+              lineHeight: "2.4rem",
+              letterSpacing: "0.4px"
+            }}
+          >
+            {T.translate("event_category_group_list.add_category_group")}
+          </Button>
+        </Grid2>
+      </Grid2>
+
+      {eventCategoryGroups.length > 0 && (
+        <MuiTable
+          columns={columns}
+          data={eventCategoryGroups}
+          options={tableOptions}
+          perPage={perPage}
+          currentPage={currentPage}
+          totalRows={totalEventCategoryGroups}
+          onPageChange={handlePageChange}
+          onPerPageChange={handlePerPageChange}
+          onSort={handleSort}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          deleteDialogBody={(name) =>
+            `${T.translate("event_category_group_list.delete_warning")} ${name}`
+          }
+          confirmButtonColor="error"
+        />
+      )}
+
+      {eventCategoryGroups.length === 0 && (
+        <div>{T.translate("event_category_group_list.no_items")}</div>
+      )}
+    </div>
+  );
+};
 
 const mapStateToProps = ({
   currentSummitState,

--- a/src/reducers/events/event-category-group-list-reducer.js
+++ b/src/reducers/events/event-category-group-list-reducer.js
@@ -9,8 +9,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ * */
 
+import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 import {
   RECEIVE_EVENT_CATEGORY_GROUPS,
   REQUEST_EVENT_CATEGORY_GROUPS,
@@ -18,10 +19,16 @@ import {
 } from "../../actions/event-category-actions";
 
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 
 const DEFAULT_STATE = {
-  eventCategoryGroups: []
+  eventCategoryGroups: [],
+  term: "",
+  order: "id",
+  orderDir: 1,
+  currentPage: 1,
+  lastPage: 1,
+  perPage: 10,
+  totalEventCategoryGroups: 0
 };
 
 const eventCategoryGroupListReducer = (state = DEFAULT_STATE, action) => {
@@ -32,24 +39,30 @@ const eventCategoryGroupListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_EVENT_CATEGORY_GROUPS: {
-      return { ...state };
+      const { order, orderDir, term, perPage } = payload;
+      return { ...state, order, orderDir, term, perPage };
     }
     case RECEIVE_EVENT_CATEGORY_GROUPS: {
-      let eventCategoryGroups = payload.response.data.map((e) => {
-        return {
-          id: e.id,
-          name: e.name,
-          color: `<div style="background-color: ${e.color}">&nbsp;</div>`,
-          type:
-            e.class_name === "PresentationCategoryGroup" ? "Public" : "Private",
-          categories: e.tracks.map((c) => c.name).join(", ")
-        };
-      });
+      const { total, last_page, current_page } = payload.response;
+      const eventCategoryGroups = payload.response.data.map((e) => ({
+        id: e.id,
+        name: e.name,
+        color: e.color,
+        type:
+          e.class_name === "PresentationCategoryGroup" ? "Public" : "Private",
+        categories: e.tracks.map((c) => c.name).join(", ")
+      }));
 
-      return { ...state, eventCategoryGroups };
+      return {
+        ...state,
+        eventCategoryGroups,
+        currentPage: current_page,
+        lastPage: last_page,
+        totalEventCategoryGroups: total
+      };
     }
     case EVENT_CATEGORY_GROUP_DELETED: {
-      let { groupId } = payload;
+      const { groupId } = payload;
       return {
         ...state,
         eventCategoryGroups: state.eventCategoryGroups.filter(

--- a/src/reducers/events/event-category-group-list-reducer.js
+++ b/src/reducers/events/event-category-group-list-reducer.js
@@ -39,8 +39,8 @@ const eventCategoryGroupListReducer = (state = DEFAULT_STATE, action) => {
       return DEFAULT_STATE;
     }
     case REQUEST_EVENT_CATEGORY_GROUPS: {
-      const { order, orderDir, term, perPage } = payload;
-      return { ...state, order, orderDir, term, perPage };
+      const { order, orderDir, term, perPage, currentPage } = payload;
+      return { ...state, order, orderDir, term, perPage, currentPage };
     }
     case RECEIVE_EVENT_CATEGORY_GROUPS: {
       const { total, last_page, current_page } = payload.response;
@@ -67,7 +67,8 @@ const eventCategoryGroupListReducer = (state = DEFAULT_STATE, action) => {
         ...state,
         eventCategoryGroups: state.eventCategoryGroups.filter(
           (g) => g.id !== groupId
-        )
+        ),
+        totalEventCategoryGroups: state.totalEventCategoryGroups - 1
       };
     }
     default:


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86badg7ka

<img width="1371" height="936" alt="image" src="https://github.com/user-attachments/assets/b310f104-176a-4316-808d-28b86280f514" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search functionality for filtering event category groups by term
  * Enabled sorting and pagination controls for the groups list  
* **Improvements**
  * Refreshed the event category groups table experience with updated columns, sorting, and pagination behavior
  * Preserved list state (search term, sorting, and page) across requests  
* **UI/Style Updates**
  * Updated the header layout and improved the color display with visual swatches
  * Refined deletion confirmation text and flow, with automatic list refresh after removal  
* **Bug Fixes**
  * Improved server-side query handling for filtering and ordering consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->