### PR TITLE
fix: make start and expire dates fields non required at ui on customi…

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/components/customized-form/customized-form.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-forms-tab/components/customized-form/customized-form.js
@@ -157,7 +157,6 @@ const CustomizedForm = ({
                 label={T.translate(
                   "edit_sponsor.forms_tab.customized_form.opens_at"
                 )}
-                required
               />
             </Grid2>
             <Grid2 size={4}>
@@ -166,7 +165,6 @@ const CustomizedForm = ({
                 label={T.translate(
                   "edit_sponsor.forms_tab.customized_form.expires_at"
                 )}
-                required
               />
             </Grid2>
             <Grid2 size={12}>


### PR DESCRIPTION
…zed form

ref: https://app.clickup.com/t/9014802374/86badfw5a

<img width="942" height="784" alt="image" src="https://github.com/user-attachments/assets/a2754ccf-cc6f-46c7-89e6-8ba3c0e19021" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated date field configuration in sponsor forms while maintaining current validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->