### PR TITLE
fix(speakers): restore activitiesCountAccurate conditional and totalActivities display

### DIFF
--- a/src/pages/summit_speakers/summit-speakers-list-page.js
+++ b/src/pages/summit_speakers/summit-speakers-list-page.js
@@ -711,8 +711,11 @@ class SummitSpeakersListPage extends React.Component {
       selectionStatusFilter,
       mediaUploadTypeFilter,
       currentFlowEvent,
-      totalActivities
+      totalActivities,
+      excludedItems
     } = this.getSubjectProps();
+
+    const activitiesCountAccurate = selectedAll && excludedItems.length === 0;
 
     const columns = [
       {
@@ -1049,9 +1052,19 @@ class SummitSpeakersListPage extends React.Component {
           <div>
             <span>
               <b>
-                {T.translate("summit_speakers_list.items_qty", {
-                  qty: selectedCount
-                })}
+                {activitiesCountAccurate
+                  ? T.translate(
+                      this.state.source === sources.speakers
+                        ? "summit_speakers_list.items_qty"
+                        : "summit_submitters_list.items_qty",
+                      { qty: selectedCount, activitiesQty: totalActivities }
+                    )
+                  : T.translate(
+                      this.state.source === sources.speakers
+                        ? "summit_speakers_list.items_qty_no_activities"
+                        : "summit_submitters_list.items_qty_no_activities",
+                      { qty: selectedCount }
+                    )}
               </b>
             </span>
             <SelectableTable


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86b9b1qrk

## Summary

- The merge of `feature/speakers-submitters-activities-count` (PR #933) into master dropped the second hunk of the `summit-speakers-list-page.js` conflict resolution: the `activitiesCountAccurate` flag computation and the conditional `T.translate` block that passes `{activitiesQty}` to the `items_qty` string.
- This left master in a broken state: `en.json` defines `items_qty` expecting an `{activitiesQty}` interpolation argument, but the page code never computes or passes it — so the activities count was silently missing from the rendered string.
- This fix restores the two missing hunks: destructuring `excludedItems` from `getSubjectProps()`, computing `activitiesCountAccurate = selectedAll && excludedItems.length === 0`, and switching to the conditional translate that passes `activitiesQty` when all items are selected with no exclusions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of activity counts displayed on the speakers/submitters list page.
  * Updated the item quantity label to show selection count and activity count when data is accurate, with a fallback display when counts may be less reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->