### PR TITLE
fix(speakers): Avoid refetching activities count unnecessarily

### DIFF
--- a/src/actions/speaker-actions.js
+++ b/src/actions/speaker-actions.js
@@ -887,14 +887,19 @@ const parseFilters = (filters) => {
   return filter;
 };
 
-const getSpeakersActivitiesCount =
-  (summitId, filter, accessToken) => (dispatch) => {
+export const getSpeakersActivitiesCount =
+  (filters = {}) =>
+  async (dispatch, getState) => {
+    const { currentSummitState } = getState();
+    const accessToken = await getAccessTokenSafely();
+    const { currentSummit } = currentSummitState;
+    const filter = parseFilters(filters);
     const params = { access_token: accessToken };
     if (filter.length > 0) params["filter[]"] = filter;
     return getRequest(
       createAction(REQUEST_SPEAKERS_ACTIVITIES_COUNT),
       createAction(RECEIVE_SPEAKERS_ACTIVITIES_COUNT),
-      `${window.API_BASE_URL}/api/v1/summits/${summitId}/speakers/all/events/count`,
+      `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/speakers/all/events/count`,
       authErrorHandler
     )(params)(dispatch);
   };
@@ -944,8 +949,6 @@ export const getSpeakersBySummit =
       const orderDirSign = orderDir === DEFAULT_ORDER_DIR ? "+" : "-";
       params.order = `${orderDirSign}${order}`;
     }
-
-    dispatch(getSpeakersActivitiesCount(currentSummit.id, filter, accessToken));
 
     return getRequest(
       createAction(REQUEST_SPEAKERS_BY_SUMMIT),

--- a/src/actions/submitter-actions.js
+++ b/src/actions/submitter-actions.js
@@ -51,14 +51,19 @@ export const initSubmittersList = () => async (dispatch) => {
   dispatch(createAction(INIT_SUBMITTERS_LIST_PARAMS)());
 };
 
-const getSubmittersActivitiesCount =
-  (summitId, filter, accessToken) => (dispatch) => {
+export const getSubmittersActivitiesCount =
+  (filters = {}) =>
+  async (dispatch, getState) => {
+    const { currentSummitState } = getState();
+    const accessToken = await getAccessTokenSafely();
+    const { currentSummit } = currentSummitState;
+    const filter = parseFilters(filters);
     const params = { access_token: accessToken };
     if (filter.length > 0) params["filter[]"] = filter;
     return getRequest(
       createAction(REQUEST_SUBMITTERS_ACTIVITIES_COUNT),
       createAction(RECEIVE_SUBMITTERS_ACTIVITIES_COUNT),
-      `${window.API_BASE_URL}/api/v1/summits/${summitId}/submitters/all/events/count`,
+      `${window.API_BASE_URL}/api/v1/summits/${currentSummit.id}/submitters/all/events/count`,
       authErrorHandler
     )(params)(dispatch);
   };
@@ -112,10 +117,6 @@ export const getSubmittersBySummit =
       const orderDirSign = orderDir === DEFAULT_ORDER_DIR ? "+" : "-";
       params.order = `${orderDirSign}${order}`;
     }
-
-    dispatch(
-      getSubmittersActivitiesCount(currentSummit.id, filter, accessToken)
-    );
 
     return getRequest(
       createAction(REQUEST_SUBMITTERS_BY_SUMMIT),

--- a/src/pages/summit_speakers/summit-speakers-list-page.js
+++ b/src/pages/summit_speakers/summit-speakers-list-page.js
@@ -24,6 +24,7 @@ import SpeakerPromoCodeSpecForm from "../../components/forms/speakers-promo-code
 import {
   initSpeakersList,
   getSpeakersBySummit,
+  getSpeakersActivitiesCount,
   exportSummitSpeakers,
   selectSummitSpeaker,
   unselectSummitSpeaker,
@@ -35,6 +36,7 @@ import {
 import {
   initSubmittersList,
   getSubmittersBySummit,
+  getSubmittersActivitiesCount,
   exportSummitSubmitters,
   selectSummitSubmitter,
   unselectSummitSubmitter,
@@ -146,13 +148,28 @@ class SummitSpeakersListPage extends React.Component {
       : this.props.submittersProps;
   }
 
-  getBySummit(term, page, perPage, order, orderDir, filters) {
+  getBySummit(
+    term,
+    page,
+    perPage,
+    order,
+    orderDir,
+    filters,
+    refreshCount = true
+  ) {
     const { source } = this.state;
     const callable =
       source === sources.speakers
         ? this.props.getSpeakersBySummit
         : this.props.getSubmittersBySummit;
     callable(term, page, perPage, order, orderDir, filters, source);
+    if (refreshCount) {
+      const countCallable =
+        source === sources.speakers
+          ? this.props.getSpeakersActivitiesCount
+          : this.props.getSubmittersActivitiesCount;
+      countCallable(filters);
+    }
   }
 
   export(term, order, orderDir, filters) {
@@ -220,15 +237,23 @@ class SummitSpeakersListPage extends React.Component {
     const {
       speakerFilters: { orAndFilter }
     } = this.state;
-    this.getBySummit(term, page, perPage, order, orderDir, {
-      selectionPlanFilter,
-      trackFilter,
-      trackGroupFilter,
-      activityTypeFilter,
-      selectionStatusFilter,
-      orAndFilter,
-      mediaUploadTypeFilter
-    });
+    this.getBySummit(
+      term,
+      page,
+      perPage,
+      order,
+      orderDir,
+      {
+        selectionPlanFilter,
+        trackFilter,
+        trackGroupFilter,
+        activityTypeFilter,
+        selectionStatusFilter,
+        orAndFilter,
+        mediaUploadTypeFilter
+      },
+      false
+    );
   }
 
   handleSort(index, key, dir) {
@@ -246,15 +271,23 @@ class SummitSpeakersListPage extends React.Component {
     const {
       speakerFilters: { orAndFilter }
     } = this.state;
-    this.getBySummit(term, page, perPage, key, dir, {
-      selectionPlanFilter,
-      trackFilter,
-      trackGroupFilter,
-      activityTypeFilter,
-      selectionStatusFilter,
-      orAndFilter,
-      mediaUploadTypeFilter
-    });
+    this.getBySummit(
+      term,
+      page,
+      perPage,
+      key,
+      dir,
+      {
+        selectionPlanFilter,
+        trackFilter,
+        trackGroupFilter,
+        activityTypeFilter,
+        selectionStatusFilter,
+        orAndFilter,
+        mediaUploadTypeFilter
+      },
+      false
+    );
   }
 
   handleSearch(term) {
@@ -273,15 +306,23 @@ class SummitSpeakersListPage extends React.Component {
     const {
       speakerFilters: { orAndFilter }
     } = this.state;
-    this.getBySummit(term, page, perPage, order, orderDir, {
-      selectionPlanFilter,
-      trackFilter,
-      trackGroupFilter,
-      activityTypeFilter,
-      selectionStatusFilter,
-      orAndFilter,
-      mediaUploadTypeFilter
-    });
+    this.getBySummit(
+      term,
+      page,
+      perPage,
+      order,
+      orderDir,
+      {
+        selectionPlanFilter,
+        trackFilter,
+        trackGroupFilter,
+        activityTypeFilter,
+        selectionStatusFilter,
+        orAndFilter,
+        mediaUploadTypeFilter
+      },
+      false
+    );
   }
 
   handleChangeSelectionPlanFilter(ev) {
@@ -1222,6 +1263,7 @@ const mapStateToProps = ({
 export default connect(mapStateToProps, {
   initSpeakersList,
   getSpeakersBySummit,
+  getSpeakersActivitiesCount,
   exportSummitSpeakers,
   selectSummitSpeaker,
   unselectSummitSpeaker,
@@ -1231,6 +1273,7 @@ export default connect(mapStateToProps, {
   sendSpeakerEmails,
   initSubmittersList,
   getSubmittersBySummit,
+  getSubmittersActivitiesCount,
   exportSummitSubmitters,
   selectSummitSubmitter,
   unselectSummitSubmitter,


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86b9b1qrk

Avoid refetching activities count on page, sort, and search changes

Activities count only depends on filters, not on pagination, sort order, or search term. Extracted getSpeakersActivitiesCount and getSubmittersActivitiesCount as standalone exported actions and moved the dispatch to getBySummit in the page, skipping it for handlePageChange, handleSort, and handleSearch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized activity count refreshing for speakers and submitters list pages to avoid unnecessary re-fetches during pagination, sorting, and search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->