### PR TITLE
fix: replace menu icon on purchases grid with download icon

### DIFF
--- a/src/pages/sponsors/show-purchase-list-page/index.js
+++ b/src/pages/sponsors/show-purchase-list-page/index.js
@@ -23,7 +23,7 @@ import {
   MenuItem,
   Select
 } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu";
+import DownloadIcon from "@mui/icons-material/Download";
 import MuiTable from "openstack-uicore-foundation/lib/components/mui/table";
 import SearchInput from "openstack-uicore-foundation/lib/components/mui/search-input";
 import history from "../../../history";
@@ -186,7 +186,7 @@ const ShowPurchaseListPage = ({
           sx={{ color: "primary.main" }}
           onClick={() => handleMenu(row)}
         >
-          <MenuIcon fontSize="large" />
+          <DownloadIcon fontSize="large" />
         </IconButton>
       )
     }

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/index.js
@@ -22,7 +22,7 @@ import {
   MenuItem,
   Select
 } from "@mui/material";
-import MenuIcon from "@mui/icons-material/Menu";
+import DownloadIcon from "@mui/icons-material/Download";
 import MuiTable from "openstack-uicore-foundation/lib/components/mui/table";
 import SearchInput from "openstack-uicore-foundation/lib/components/mui/search-input";
 import history from "../../../../../history";
@@ -169,7 +169,7 @@ const SponsorPurchasesTab = ({
           sx={{ color: "primary.main" }}
           onClick={() => handleMenu(row)}
         >
-          <MenuIcon fontSize="large" />
+          <DownloadIcon fontSize="large" />
         </IconButton>
       )
     }


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bahg5pj

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the action icon in sponsor purchase tables to a download symbol for a clearer, more consistent visual cue.
  * The change applies to sponsor purchase list views and related sponsor purchases tabs, with no impact on functionality or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->