### PR TITLE
fix: add truncate text on badge-scans email columns

### DIFF
--- a/src/pages/sponsors/badge-scans-list-page.js
+++ b/src/pages/sponsors/badge-scans-list-page.js
@@ -14,7 +14,7 @@
 import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import T from "i18n-react/dist/i18n-react";
-import Table from "openstack-uicore-foundation/lib/components/table"
+import Table from "openstack-uicore-foundation/lib/components/table";
 import SponsorInput from "openstack-uicore-foundation/lib/components/inputs/sponsor-input";
 import { querySponsorsWithBadgeScans } from "openstack-uicore-foundation/lib/utils/query-actions";
 import { Pagination } from "react-bootstrap";
@@ -100,7 +100,8 @@ const BadgeScansListPage = ({
     {
       columnKey: "attendee_email",
       value: T.translate("badge_scan_list.email"),
-      sortable: true
+      sortable: true,
+      truncateText: true
     },
     {
       columnKey: "attendee_company",

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-badge-scans/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-badge-scans/index.js
@@ -151,7 +151,8 @@ const SponsorBadgeScans = ({
     {
       columnKey: "attendee_email",
       header: T.translate("sponsor_badge_scans.email"),
-      sortable: true
+      sortable: true,
+      truncateText: true
     },
     {
       columnKey: "attendee_company",


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86barhpdq

<img width="1216" height="943" alt="image" src="https://github.com/user-attachments/assets/5bb7a9d6-a1b8-45cf-8399-bd3139866bbe" />

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the attendee email column in badge scan tables to truncate long text, improving readability and preventing layout overflow.
  * Kept email sorting available while making the column display more compact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->