### PR TITLE
fix: catch missing file_mimetype on media upload to render view column

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-media-upload-tab/index.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-media-upload-tab/index.js
@@ -170,7 +170,7 @@ const SponsorMediaUploadTab = ({
         width: 80,
         align: "center",
         render: (row) => {
-          const isImage = row.media_upload?.file_mimetype.includes("image");
+          const isImage = row.media_upload?.file_mimetype?.includes("image");
           return (
             <IconButton
               size="large"


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bat2q03

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media detection in the sponsor media upload view so missing file data no longer causes errors.
  * Rows without image information are now handled safely and the view action is disabled when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->