### PR TITLE
fix: add purchase_date catch for pending orders, replace created prop…

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2696,6 +2696,7 @@
       "order_details": {
         "order": "Order",
         "purchase_date": "Purchase Date",
+        "pending": "Pending",
         "purchased_by": "Purchased by",
         "show": "Show",
         "sponsor": "Sponsor",

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/sponsor-order-details.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/sponsor-order-details.js
@@ -29,7 +29,6 @@ import {
 import {
   ACCESS_ROUTES,
   DATE_FORMAT,
-  PURCHASE_STATUS,
   PURCHASE_TYPES
 } from "../../../../../utils/constants";
 import Restrict from "../../../../../routes/restrict";
@@ -68,7 +67,7 @@ const SponsorOrderDetails = ({
       ),
       value: currentOrder.purchased_date
         ? formatDate(currentOrder.purchased_date, "LOC", DATE_FORMAT)
-        : PURCHASE_STATUS.PENDING
+        : T.translate("edit_sponsor.purchase_tab.order_details.pending")
     },
     {
       label: T.translate(

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/sponsor-order-details.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-purchases-tab/sponsor-order-details.js
@@ -29,6 +29,7 @@ import {
 import {
   ACCESS_ROUTES,
   DATE_FORMAT,
+  PURCHASE_STATUS,
   PURCHASE_TYPES
 } from "../../../../../utils/constants";
 import Restrict from "../../../../../routes/restrict";
@@ -65,7 +66,9 @@ const SponsorOrderDetails = ({
       label: T.translate(
         "edit_sponsor.purchase_tab.order_details.purchase_date"
       ),
-      value: formatDate(currentOrder.created, "LOC", DATE_FORMAT)
+      value: currentOrder.purchased_date
+        ? formatDate(currentOrder.purchased_date, "LOC", DATE_FORMAT)
+        : PURCHASE_STATUS.PENDING
     },
     {
       label: T.translate(

--- a/src/reducers/sponsors/show-purchase-list-reducer.js
+++ b/src/reducers/sponsors/show-purchase-list-reducer.js
@@ -20,7 +20,10 @@ import {
   SPONSOR_PURCHASE_STATUS_UPDATED
 } from "../../actions/sponsor-purchases-actions";
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import { MILLISECONDS_TO_SECONDS } from "../../utils/constants";
+import {
+  MILLISECONDS_TO_SECONDS,
+  PURCHASE_STATUS
+} from "../../utils/constants";
 
 const DEFAULT_STATE = {
   purchases: [],
@@ -70,7 +73,7 @@ const showPurchaseListReducer = (state = DEFAULT_STATE, action) => {
           ? moment(a.purchased_date * MILLISECONDS_TO_SECONDS).format(
               "YYYY/MM/DD HH:mm a"
             )
-          : "N/A"
+          : PURCHASE_STATUS.PENDING
       }));
 
       return {

--- a/src/reducers/sponsors/show-purchase-list-reducer.js
+++ b/src/reducers/sponsors/show-purchase-list-reducer.js
@@ -12,6 +12,7 @@
  * */
 
 import moment from "moment-timezone";
+import T from "i18n-react/dist/i18n-react";
 import { amountFromCents } from "openstack-uicore-foundation/lib/utils/money";
 import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 import {
@@ -20,10 +21,7 @@ import {
   SPONSOR_PURCHASE_STATUS_UPDATED
 } from "../../actions/sponsor-purchases-actions";
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import {
-  MILLISECONDS_TO_SECONDS,
-  PURCHASE_STATUS
-} from "../../utils/constants";
+import { MILLISECONDS_TO_SECONDS } from "../../utils/constants";
 
 const DEFAULT_STATE = {
   purchases: [],
@@ -73,7 +71,7 @@ const showPurchaseListReducer = (state = DEFAULT_STATE, action) => {
           ? moment(a.purchased_date * MILLISECONDS_TO_SECONDS).format(
               "YYYY/MM/DD HH:mm a"
             )
-          : PURCHASE_STATUS.PENDING
+          : T.translate("edit_sponsor.purchase_tab.order_details.pending")
       }));
 
       return {

--- a/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
@@ -24,7 +24,10 @@ import {
   SPONSOR_PURCHASE_STATUS_UPDATED
 } from "../../actions/sponsor-purchases-actions";
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import { MILLISECONDS_TO_SECONDS } from "../../utils/constants";
+import {
+  MILLISECONDS_TO_SECONDS,
+  PURCHASE_STATUS
+} from "../../utils/constants";
 import { normalizeOrder } from "../../pages/sponsors/sponsor-page/utils";
 
 const DEFAULT_STATE = {
@@ -71,9 +74,11 @@ const sponsorPagePurchaseListReducer = (state = DEFAULT_STATE, action) => {
         ...a,
         order: a.order_number,
         amount: `$${amountFromCents(a.net_amount)}`,
-        purchased: moment(a.purchased_date * MILLISECONDS_TO_SECONDS).format(
-          "YYYY/MM/DD HH:mm a"
-        )
+        purchased: a.purchased_date
+          ? moment(a.purchased_date * MILLISECONDS_TO_SECONDS).format(
+              "YYYY/MM/DD HH:mm a"
+            )
+          : PURCHASE_STATUS.PENDING
       }));
 
       return {

--- a/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
+++ b/src/reducers/sponsors/sponsor-page-purchase-list-reducer.js
@@ -12,6 +12,7 @@
  * */
 
 import moment from "moment-timezone";
+import T from "i18n-react/dist/i18n-react";
 import { amountFromCents } from "openstack-uicore-foundation/lib/utils/money";
 import { LOGOUT_USER } from "openstack-uicore-foundation/lib/security/actions";
 import {
@@ -24,10 +25,7 @@ import {
   SPONSOR_PURCHASE_STATUS_UPDATED
 } from "../../actions/sponsor-purchases-actions";
 import { SET_CURRENT_SUMMIT } from "../../actions/summit-actions";
-import {
-  MILLISECONDS_TO_SECONDS,
-  PURCHASE_STATUS
-} from "../../utils/constants";
+import { MILLISECONDS_TO_SECONDS } from "../../utils/constants";
 import { normalizeOrder } from "../../pages/sponsors/sponsor-page/utils";
 
 const DEFAULT_STATE = {
@@ -78,7 +76,7 @@ const sponsorPagePurchaseListReducer = (state = DEFAULT_STATE, action) => {
           ? moment(a.purchased_date * MILLISECONDS_TO_SECONDS).format(
               "YYYY/MM/DD HH:mm a"
             )
-          : PURCHASE_STATUS.PENDING
+          : T.translate("edit_sponsor.purchase_tab.order_details.pending")
       }));
 
       return {


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bay73p5

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Purchase/order details now show the actual purchase date when available.
  - Purchases without a `purchased_date` are labeled **Pending** (localized) instead of “N/A” or formatting an incorrect/placeholder value.
  - Updated both the sponsor purchase list and order details to consistently reflect pending purchase status.
- **Localization**
  - Added an i18n string for the **Pending** label in the sponsor purchase/order details area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->