### PR TITLE
Sponsor Reports: contained forms display and sponsor booth fallback

### DIFF
--- a/src/components/sponsors/reports/ByItemView.js
+++ b/src/components/sponsors/reports/ByItemView.js
@@ -366,11 +366,9 @@ const ByItemView = ({
                                       <TableCell>{c.number}</TableCell>
                                       <TableCell>{c.formCode}</TableCell>
                                       <TableCell>
-                                        {/* || not ??: empty-string add-on falls
-                                            through to the booth, mirroring
-                                            LinesManifestView */}
                                         <Destination
-                                          name={c.addOnName || c.sponsorBooth}
+                                          name={c.addOnName}
+                                          booth={c.sponsorBooth}
                                         />
                                       </TableCell>
                                       <TableCell>

--- a/src/components/sponsors/reports/ByItemView.js
+++ b/src/components/sponsors/reports/ByItemView.js
@@ -114,6 +114,7 @@ export const groupLinesBySponsorItem = (rows = []) => {
       number: row.purchase?.number ?? "",
       formCode: row.form?.code ?? "",
       addOnName: row.add_on_name ?? null,
+      sponsorBooth: row.sponsor_booth ?? null,
       checkoutAt: row.purchase?.checkout_at ?? null,
       rateName: row.rate_name ?? "",
       status: row.purchase?.status ?? "",
@@ -365,7 +366,12 @@ const ByItemView = ({
                                       <TableCell>{c.number}</TableCell>
                                       <TableCell>{c.formCode}</TableCell>
                                       <TableCell>
-                                        <Destination name={c.addOnName} />
+                                        {/* || not ??: empty-string add-on falls
+                                            through to the booth, mirroring
+                                            LinesManifestView */}
+                                        <Destination
+                                          name={c.addOnName || c.sponsorBooth}
+                                        />
                                       </TableCell>
                                       <TableCell>
                                         {formatCheckoutTime(c.checkoutAt)}

--- a/src/components/sponsors/reports/LinesManifestView.js
+++ b/src/components/sponsors/reports/LinesManifestView.js
@@ -53,14 +53,18 @@ export const PER_PAGE_OPTIONS = [
 // logistics convention is the sponsor's booth — the API supplies it as
 // `sponsor_booth` (the sponsor's Booth-type add-on name(s)). The muted "Booth"
 // placeholder remains only for sponsors with no booth add-on on file.
-export const Destination = ({ name }) =>
-  name ? (
-    <>{name}</>
+// `name || booth`, not ??: an empty-string add-on falls through to the booth,
+// matching the backend CSV's `or` precedence.
+export const Destination = ({ name, booth }) => {
+  const label = name || booth;
+  return label ? (
+    <>{label}</>
   ) : (
     <Typography component="span" variant="body2" color="text.disabled">
       {T.translate("sponsor_reports_page.destination_booth_fallback")}
     </Typography>
   );
+};
 
 // Buckets flat per-line rows into sponsor groups, preserving first-seen order.
 //
@@ -162,10 +166,9 @@ const LinesManifestView = ({
                       <TableCell>{line.item_code}</TableCell>
                       <TableCell>{line.description}</TableCell>
                       <TableCell>
-                        {/* || not ??: an empty-string add_on_name falls through to the
-                            booth, matching the backend CSV's `or` precedence */}
                         <Destination
-                          name={line.add_on_name || line.sponsor_booth}
+                          name={line.add_on_name}
+                          booth={line.sponsor_booth}
                         />
                       </TableCell>
                       <TableCell>

--- a/src/components/sponsors/reports/LinesManifestView.js
+++ b/src/components/sponsors/reports/LinesManifestView.js
@@ -50,8 +50,9 @@ export const PER_PAGE_OPTIONS = [
 ];
 
 // Destination = the line's add-on (e.g. "Meeting Room T"); when absent, the
-// logistics convention is the sponsor's booth. The booth NUMBER ships with
-// slice #1 — until then show a muted "Booth" placeholder.
+// logistics convention is the sponsor's booth — the API supplies it as
+// `sponsor_booth` (the sponsor's Booth-type add-on name(s)). The muted "Booth"
+// placeholder remains only for sponsors with no booth add-on on file.
 export const Destination = ({ name }) =>
   name ? (
     <>{name}</>
@@ -161,7 +162,11 @@ const LinesManifestView = ({
                       <TableCell>{line.item_code}</TableCell>
                       <TableCell>{line.description}</TableCell>
                       <TableCell>
-                        <Destination name={line.add_on_name} />
+                        {/* || not ??: an empty-string add_on_name falls through to the
+                            booth, matching the backend CSV's `or` precedence */}
+                        <Destination
+                          name={line.add_on_name || line.sponsor_booth}
+                        />
                       </TableCell>
                       <TableCell>
                         {formatCheckoutTime(line.purchase?.checkout_at)}

--- a/src/components/sponsors/reports/OrdersTable.js
+++ b/src/components/sponsors/reports/OrdersTable.js
@@ -78,7 +78,16 @@ const columns = [
     columnKey: "form_display",
     header: T.translate("sponsor_reports_page.col_type"),
     sortable: false, // not a backend ordering field
-    render: (row) => row.form?.display ?? ""
+    // `forms` is the order's full contained form set (the form_code filter matches by
+    // containment, so the row must show every form, not just the first line's label).
+    // Falls back to the legacy first-line `form.display` until the API ships `forms`.
+    // A null form name is a pre-backfill row: show the bare code.
+    render: (row) =>
+      row.forms?.length
+        ? row.forms
+            .map((f) => (f.name ? `${f.code} - ${f.name}` : f.code))
+            .join(", ")
+        : row.form?.display ?? ""
   },
   {
     columnKey: "status",

--- a/src/components/sponsors/reports/__tests__/ByItemView.test.js
+++ b/src/components/sponsors/reports/__tests__/ByItemView.test.js
@@ -133,6 +133,7 @@ describe("groupLinesBySponsorItem", () => {
       number: "OCP-1",
       formCode: "AV",
       addOnName: "Meeting Room T",
+      sponsorBooth: null,
       checkoutAt: 1735000000,
       rateName: "Early",
       status: "Paid",
@@ -372,5 +373,45 @@ describe("ByItemView", () => {
     fireEvent.mouseDown(screen.getByRole("combobox"));
     fireEvent.click(screen.getByRole("option", { name: "20" }));
     expect(onPerPageChange).toHaveBeenCalledWith(20);
+  });
+});
+
+describe("Destination booth fallback (By Item drill-down)", () => {
+  it("carries sponsor_booth through grouping as contributor sponsorBooth", () => {
+    const [withBooth] = groupLinesBySponsorItem([
+      line({ sponsor_booth: "C3 | C4" })
+    ]);
+    expect(withBooth.items[0].contributors[0].sponsorBooth).toBe("C3 | C4");
+    const [without] = groupLinesBySponsorItem([line()]);
+    expect(without.items[0].contributors[0].sponsorBooth).toBeNull();
+  });
+
+  it("drill-down falls back to the sponsor booth on an empty add-on (|| precedence)", () => {
+    renderView({
+      groups: [
+        group({
+          items: [
+            item({
+              contributors: [
+                {
+                  number: "OCP-1",
+                  formCode: "AV",
+                  addOnName: "",
+                  sponsorBooth: "C3 | C4",
+                  checkoutAt: 1735000000,
+                  rateName: "Early",
+                  status: "Paid",
+                  qty: 3,
+                  lineTotalCents: 150000,
+                  isCanceled: false
+                }
+              ]
+            })
+          ]
+        })
+      ]
+    });
+    fireEvent.click(screen.getByText("AV1"));
+    expect(screen.getByText("C3 | C4")).toBeInTheDocument();
   });
 });

--- a/src/components/sponsors/reports/__tests__/LinesManifestView.test.js
+++ b/src/components/sponsors/reports/__tests__/LinesManifestView.test.js
@@ -105,3 +105,36 @@ describe("LinesManifestView", () => {
     });
   });
 });
+
+describe("Destination booth fallback", () => {
+  it("prefers the line's own add_on_name over sponsor_booth", () => {
+    renderView({ rows: [line({ sponsor_booth: "C3 | C4" })] });
+    expect(screen.getByText("Meeting Room T")).toBeInTheDocument();
+    expect(screen.queryByText("C3 | C4")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the sponsor's booth when the line has no add-on", () => {
+    renderView({
+      rows: [line({ add_on_name: null, sponsor_booth: "C3 | C4" })]
+    });
+    expect(screen.getByText("C3 | C4")).toBeInTheDocument();
+  });
+
+  it("falls back on an EMPTY-STRING add_on_name (|| precedence, matching the backend CSV's `or`)", () => {
+    // discriminates || from ??: a ?? implementation would render the muted
+    // placeholder here instead of the booth
+    renderView({
+      rows: [line({ add_on_name: "", sponsor_booth: "C3 | C4" })]
+    });
+    expect(screen.getByText("C3 | C4")).toBeInTheDocument();
+  });
+
+  it("keeps the muted placeholder when neither add-on nor booth exists", () => {
+    renderView({
+      rows: [line({ add_on_name: null, sponsor_booth: null })]
+    });
+    expect(
+      screen.getByText("sponsor_reports_page.destination_booth_fallback")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sponsors/reports/__tests__/OrdersTable.test.js
+++ b/src/components/sponsors/reports/__tests__/OrdersTable.test.js
@@ -78,3 +78,35 @@ describe("OrdersTable finance columns", () => {
     expect(screen.getAllByText("—")).toHaveLength(4);
   });
 });
+
+describe("OrdersTable Type column (contained forms)", () => {
+  it("renders the full contained form set joined when forms is present", () => {
+    renderTable([
+      {
+        ...sampleRow,
+        forms: [
+          { code: "CL", name: "Cleaning" },
+          { code: "EL", name: "Electrical" }
+        ]
+      }
+    ]);
+    expect(
+      screen.getByText("CL - Cleaning, EL - Electrical")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to form.display when forms is absent (pre-deploy API)", () => {
+    renderTable(); // sampleRow has no forms property
+    expect(screen.getByText("Booth")).toBeInTheDocument();
+  });
+
+  it("falls back to form.display when forms is an empty array", () => {
+    renderTable([{ ...sampleRow, forms: [] }]);
+    expect(screen.getByText("Booth")).toBeInTheDocument();
+  });
+
+  it("renders the bare code when a form name is null (pre-backfill rows)", () => {
+    renderTable([{ ...sampleRow, forms: [{ code: "CL", name: null }] }]);
+    expect(screen.getByText("CL")).toBeInTheDocument();
+  });
+});

--- a/src/components/sponsors/reports/__tests__/OrdersTable.test.js
+++ b/src/components/sponsors/reports/__tests__/OrdersTable.test.js
@@ -109,4 +109,9 @@ describe("OrdersTable Type column (contained forms)", () => {
     renderTable([{ ...sampleRow, forms: [{ code: "CL", name: null }] }]);
     expect(screen.getByText("CL")).toBeInTheDocument();
   });
+
+  it("renders the bare code when a form name is an empty string", () => {
+    renderTable([{ ...sampleRow, forms: [{ code: "CL", name: "" }] }]);
+    expect(screen.getByText("CL")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
ref: https://app.clickup.com/t/86bazmggh

Frontend half of the summit-73 Purchase Details ops fixes. Consumes two additive fields the sponsor-reports-api backend now ships (fntechgit/sponsor-reports-api#33 and #34); both renders degrade gracefully against the pre-deploy API shape, so merge order does not matter.

## Changes

- **OrdersTable Type column** renders the order's full contained form set ("CL - Cleaning, EL - Electrical") from the new `forms` field. The backend `form_code` filter matches by containment, so showing only the first line's label made filtered rows look wrong. Falls back to the legacy `form.display` until the API ships `forms`, and shows the bare code for pre-backfill rows whose form name is null.
- **Destination fallback in both lines views** (LinesManifestView and the By Item drill-down): `add_on_name || sponsor_booth` — `||` deliberately, matching the backend CSV's `or` precedence so an empty-string add-on falls through to the booth. The muted "Booth" placeholder now appears only for sponsors with no Booth add-on on file.

## Scope

6 files (3 components + their 3 test files), +131/−5. No new files; reducers pass API rows through verbatim, so no action/reducer/i18n changes. `Destination` and all existing helpers reused.

## Testing

TDD (each behavior red first). New tests pin: the join format, null-name and absent/empty `forms` fallbacks, `||` precedence including the empty-string case, the muted-placeholder path, and the By Item contributor mapping. Full suite: 1394/1395 — the one failure is `sponsor-users-actions.test.js`, which fails identically on a clean master checkout (pre-existing, unrelated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Destination booth displays now correctly fall back to the sponsor’s booth when add-on information is missing or blank.
  * Orders tables now show all contained forms, including form codes and names, while preserving compatibility with older records.
  * Form entries without names now display their codes without extra formatting.

* **Tests**
  * Added coverage for destination booth fallbacks and contained-form display scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->