### PR TITLE
 fix: adjust text label on wire transfer notification email

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2358,7 +2358,7 @@
     "onsite_price_start_date": "On-site ordering starts at",
     "onsite_price_end_date": "On-site ordering closes at",
     "wire_transfer_fee": "Wire Transfer Fee",
-    "wire_transfer_notification_email": "Wire Transfer Notification e-mail",
+    "wire_transfer_notification_email": "Wire Transfer Notification email - (separate by ; for multiples)",
     "is_wire_transfer_enabled": "Enable wire transfer",
     "wire_transfer_detail": "Wire Transfer Detail",
     "cart_checkout_cancel_policy": "Checkout Cancel Policy",


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bb5ea4m

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sponsor settings label to use “email” instead of “e-mail” for consistent wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->