### PR TITLE
fix(event-form): allow event dates outside the summit's date range

### DIFF
--- a/src/components/forms/__tests__/event-form.test.js
+++ b/src/components/forms/__tests__/event-form.test.js
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import EventForm from "../event-form";
+import currentSummitMock from "../../../__mocks__/currentSummitMock";
+
+jest.mock("i18n-react/dist/i18n-react", () => ({
+  __esModule: true,
+  default: { translate: (key) => key }
+}));
+
+describe("EventForm", () => {
+  const marketplaceHoursType = currentSummitMock.event_types.find(
+    (t) => t.id === 935
+  );
+
+  const baseProps = {
+    history: { push: jest.fn() },
+    currentSummit: currentSummitMock,
+    levelOpts: [],
+    trackOpts: currentSummitMock.tracks,
+    typeOpts: currentSummitMock.event_types,
+    locationOpts: currentSummitMock.locations,
+    selectionPlansOpts: [],
+    rsvpTemplateOpts: [],
+    actionTypes: [],
+    entity: {
+      id: 0,
+      title: "Test Event",
+      type_id: marketplaceHoursType.id,
+      track_id: 0,
+      location_id: 0,
+      start_date: currentSummitMock.start_date + 3600,
+      end_date: currentSummitMock.start_date + 7200,
+      duration: 3600,
+      is_published: false,
+      description: "",
+      speakers: [],
+      moderator: null,
+      sponsors: [],
+      tags: [],
+      extra_questions: []
+    },
+    errors: {},
+    onSubmit: jest.fn(),
+    onSaveIncomplete: jest.fn(),
+    onUpdate: jest.fn(),
+    onEventUpgrade: jest.fn(),
+    onAttach: jest.fn(),
+    onUnpublish: jest.fn(),
+    onMaterialDelete: jest.fn(),
+    onRemoveImage: jest.fn(),
+    onAddQAMember: jest.fn(),
+    onDeleteQAMember: jest.fn(),
+    feedbackState: { term: "", page: 1, comments: [] },
+    getEventFeedback: jest.fn(),
+    fetchExtraQuestions: jest.fn(),
+    fetchExtraQuestionsAnswers: jest.fn(),
+    commentState: { filters: {}, comments: [] },
+    getEventComments: jest.fn(),
+    onCommentDelete: jest.fn(),
+    deleteEventFeedback: jest.fn(),
+    getEventFeedbackCSV: jest.fn(),
+    onFlagChange: jest.fn(),
+    onClone: jest.fn()
+  };
+
+  // The calendar popup opens on the summit's start month (October 2025) for
+  // both fields, so day 28 (Sep 28, rendered as "rdtOld") is the day right
+  // before the summit's start date in both pickers.
+  const getDayBeforeSummitStartCell = (container) =>
+    container.querySelector("td.rdtOld[data-value=\"28\"]");
+
+  test("does not disable a date before the summit's start date on the Start Date calendar", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<EventForm {...baseProps} />);
+
+    const startDateInput = screen.getByPlaceholderText(
+      "edit_event.placeholders.start_date"
+    );
+    await user.click(startDateInput);
+
+    const dayBeforeSummitStart = getDayBeforeSummitStartCell(container);
+    expect(dayBeforeSummitStart).not.toHaveClass("rdtDisabled");
+  });
+
+  test("does not disable a date before the summit's start date on the End Date calendar", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<EventForm {...baseProps} />);
+
+    const endDateInput = screen.getByPlaceholderText(
+      "edit_event.placeholders.end_date"
+    );
+    await user.click(endDateInput);
+
+    const dayBeforeSummitStart = getDayBeforeSummitStartCell(container);
+    expect(dayBeforeSummitStart).not.toHaveClass("rdtDisabled");
+  });
+});

--- a/src/components/forms/event-form.js
+++ b/src/components/forms/event-form.js
@@ -1244,10 +1244,6 @@ class EventForm extends React.Component {
                 <DateTimePicker
                   id="start_date"
                   onChange={this.handleTimeChange}
-                  validation={{
-                    after: currentSummit.start_date,
-                    before: currentSummit.end_date
-                  }}
                   format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
                   value={epochToMomentTimeZone(
                     entity.start_date,
@@ -1271,10 +1267,6 @@ class EventForm extends React.Component {
                 <DateTimePicker
                   id="end_date"
                   onChange={this.handleTimeChange}
-                  validation={{
-                    after: currentSummit.start_date,
-                    before: currentSummit.end_date
-                  }}
                   format={{ date: "YYYY-MM-DD", time: "HH:mm" }}
                   value={epochToMomentTimeZone(
                     entity.end_date,


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bb66urv
## Summary

The single-event edit form's Start Date / End Date pickers were hard-clamped to the summit's own `start_date`/`end_date` via the `validation` prop on `DateTimePicker`. This disabled calendar days outside that range, blocking an admin from publishing an event scheduled before/after the summit itself.

Reported live on summit 73, event 8519 (`/app/summits/73/events/8519`).

## Change

- Remove the `validation={{ after: currentSummit.start_date, before: currentSummit.end_date }}` prop from both the `start_date` and `end_date` `DateTimePicker` instances in `src/components/forms/event-form.js`.
- No other logic in this file enforces the summit-date range (only presence/duration ordering checks remain, both untouched).

## Out of scope

- Events Bulk Editor has the same clamp, but there the `is_valid` gate on Apply/Publish comes from the shared `openstack-uicore-foundation` library's `SummitEvent.isValidStartDate/isValidEndDate` (also used in the bulk-actions reducer) — removing it requires reworking that gating in 3 places, deferred as a follow-up.
- Schedule builder "empty spots" modal intentionally keeps its summit-date clamp (it searches within the summit's own schedule).

## Testing

- New unit test class `src/components/forms/__tests__/event-form.test.js` (no prior coverage for this file): renders `EventForm` and asserts the calendar popup no longer marks a day before the summit's start date as `rdtDisabled`, for both fields. Verified RED against the pre-fix code (fails with `rdtDisabled` present) and GREEN after the fix.
- Full suite: 154/154 suites, 1398/1398 tests passing.
- `eslint` on changed files: 0 errors (pre-existing warnings unrelated to this change).

Plan: `docs/plans/2026-07-30-event-dates-outside-summit.md`
ClickUp: https://app.clickup.com/t/86bb66urv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event date selection to allow dates immediately before the summit start date in both Start Date and End Date calendars.

* **Tests**
  * Added coverage verifying that dates before the summit start date remain selectable in both date pickers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->