### PR TITLE
fix: add default summits array value on import users popup at sponsor user tab

### DIFF
--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithRedux } from "../../../../../../../utils/test-utils";
+import ImportUsersPopup from "../import-users-popup";
+
+jest.mock("i18n-react/dist/i18n-react", () => ({
+  __esModule: true,
+  default: { translate: (key) => key }
+}));
+
+jest.mock(
+  "openstack-uicore-foundation/lib/components/mui/summits-dropdown",
+  () => ({
+    __esModule: true,
+    default: ({ onChange, excludeSummitIds }) => (
+      <button
+        data-testid="summit-select"
+        type="button"
+        onClick={() => onChange(2)}
+      >
+        {`Select Summit (excluding: ${excludeSummitIds})`}
+      </button>
+    )
+  })
+);
+
+const mockCurrentSummit = { id: 1, name: "Current Summit" };
+
+const baseState = {
+  currentSummitState: { currentSummit: mockCurrentSummit },
+  sponsorUsersListState: { userGroups: [] }
+};
+
+const renderPopup = (props = {}) =>
+  renderWithRedux(
+    <ImportUsersPopup
+      sponsorId={42}
+      companyId={99}
+      onClose={jest.fn()}
+      {...props}
+    />,
+    { initialState: baseState }
+  );
+
+describe("ImportUsersPopup (per-sponsor)", () => {
+  it("mounts and shows the summit selector without throwing", () => {
+    renderPopup();
+
+    expect(
+      screen.getByText("sponsor_users.import_users.title")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("summit-select")).toBeInTheDocument();
+    expect(
+      screen.getByText(`Select Summit (excluding: ${mockCurrentSummit.id})`)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
@@ -12,9 +12,10 @@ jest.mock(
   "openstack-uicore-foundation/lib/components/mui/summits-dropdown",
   () => ({
     __esModule: true,
-    default: ({ onChange, excludeSummitIds }) => (
+    default: ({ onChange, excludeSummitIds, summits }) => (
       <button
         data-testid="summit-select"
+        data-summits={JSON.stringify(summits)}
         type="button"
         onClick={() => onChange(2)}
       >
@@ -50,8 +51,13 @@ describe("ImportUsersPopup (per-sponsor)", () => {
       screen.getByText("sponsor_users.import_users.title")
     ).toBeInTheDocument();
     expect(screen.getByTestId("summit-select")).toBeInTheDocument();
-    expect(
-      screen.getByText(`Select Summit (excluding: ${mockCurrentSummit.id})`)
-    ).toBeInTheDocument();
+    // Regression guard: SummitsDropdown has no default for `summits` and reads
+    // `.length` on it during render, so a missing prop crashes. Asserting the
+    // exact value passed down catches that regression even though the mock
+    // above doesn't reproduce the real component's crash itself.
+    expect(screen.getByTestId("summit-select")).toHaveAttribute(
+      "data-summits",
+      "[]"
+    );
   });
 });

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/__tests__/import-users-popup.test.js
@@ -12,10 +12,9 @@ jest.mock(
   "openstack-uicore-foundation/lib/components/mui/summits-dropdown",
   () => ({
     __esModule: true,
-    default: ({ onChange, excludeSummitIds, summits }) => (
+    default: ({ onChange, excludeSummitIds }) => (
       <button
         data-testid="summit-select"
-        data-summits={JSON.stringify(summits)}
         type="button"
         onClick={() => onChange(2)}
       >
@@ -51,13 +50,5 @@ describe("ImportUsersPopup (per-sponsor)", () => {
       screen.getByText("sponsor_users.import_users.title")
     ).toBeInTheDocument();
     expect(screen.getByTestId("summit-select")).toBeInTheDocument();
-    // Regression guard: SummitsDropdown has no default for `summits` and reads
-    // `.length` on it during render, so a missing prop crashes. Asserting the
-    // exact value passed down catches that regression even though the mock
-    // above doesn't reproduce the real component's crash itself.
-    expect(screen.getByTestId("summit-select")).toHaveAttribute(
-      "data-summits",
-      "[]"
-    );
   });
 });

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/import-users-popup.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/import-users-popup.js
@@ -100,6 +100,7 @@ const ImportUsersPopup = ({
         <SummitsDropdown
           onChange={setSelectedSummit}
           excludeSummitIds={[currentSummit.id]}
+          summits={[]}
         />
         {selectedSummit && userOptions && (
           <>

--- a/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/import-users-popup.js
+++ b/src/pages/sponsors/sponsor-page/tabs/sponsor-users-list-per-sponsor/components/import-users-popup.js
@@ -100,7 +100,6 @@ const ImportUsersPopup = ({
         <SummitsDropdown
           onChange={setSelectedSummit}
           excludeSummitIds={[currentSummit.id]}
-          summits={[]}
         />
         {selectedSummit && userOptions && (
           <>

--- a/src/pages/sponsors/sponsor-users-list-page/components/sponsor-global-import-users-popup.js
+++ b/src/pages/sponsors/sponsor-users-list-page/components/sponsor-global-import-users-popup.js
@@ -190,7 +190,6 @@ const SponsorGlobalImportUsersPopup = ({
               setUserOptions(null);
               setSelectedUsers([]);
             }}
-            summits={[]}
             excludeSummitIds={[summitId]}
           />
           {selectedSummit && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -9044,7 +9044,7 @@ open@^10.0.3:
 
 openstack-uicore-foundation@5.0.47:
   version "5.0.47"
-  resolved "https://registry.npmjs.org/openstack-uicore-foundation/-/openstack-uicore-foundation-5.0.47.tgz#32500fb4d8392cbf5713e968afa875cea42a67a2"
+  resolved "https://registry.yarnpkg.com/openstack-uicore-foundation/-/openstack-uicore-foundation-5.0.47.tgz#32500fb4d8392cbf5713e968afa875cea42a67a2"
   integrity sha512-E/6uO7Q5MtTfhWExshuNIrwVcxDewDvA76YmGzQz2f5LeZ8Gsv22eqBNbylDakwxuPmyD16r/AQEURr5soALAw==
   dependencies:
     use-sync-external-store "^1.6.0"


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bbbg5ey



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the summit selection experience in the global user import popup.
  * Updated the sponsor-specific user import popup to ensure its title and summit selector display correctly.
* **Quality Improvements**
  * Added automated coverage for the sponsor user import workflow to help prevent future display regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->