### PR TITLE
fix: sort By Item sponsor groups alphabetically

### DIFF
--- a/src/components/sponsors/reports/ByItemView.js
+++ b/src/components/sponsors/reports/ByItemView.js
@@ -177,10 +177,16 @@ export const groupLinesBySponsorItem = (rows = []) => {
       purchasedCount: items.filter((it) => it.qty > 0).length
     };
   });
-  groups.sort(
-    (a, b) =>
-      b.totalQty - a.totalQty || a.sponsorName.localeCompare(b.sponsorName)
-  );
+  // Nothing sorts the sponsor accordions explicitly (the column headers reorder
+  // items WITHIN a group), so they default to alphabetical — same convention as
+  // the pivot tree: unknown bucket last, then label asc case-insensitive. This
+  // also decides which sponsors land on which client-side page.
+  groups.sort((a, b) => {
+    if (!a.sponsorName !== !b.sponsorName) return a.sponsorName ? -1 : 1;
+    return a.sponsorName
+      .toLowerCase()
+      .localeCompare(b.sponsorName.toLowerCase());
+  });
   return groups;
 };
 
@@ -639,7 +645,7 @@ const ByItemView = ({
           >
             <ItemTable
               // Sorting reorders items WITHIN each sponsor; the sponsor
-              // accordions keep their own fixed totalQty order.
+              // accordions stay alphabetical.
               items={sortItems(group.items, order, orderDir)}
               keyFor={(item) => itemKey(group, item)}
               expandedItems={expandedItems}

--- a/src/components/sponsors/reports/ByItemView.js
+++ b/src/components/sponsors/reports/ByItemView.js
@@ -178,9 +178,13 @@ export const groupLinesBySponsorItem = (rows = []) => {
     };
   });
   // Nothing sorts the sponsor accordions explicitly (the column headers reorder
-  // items WITHIN a group), so they default to alphabetical — same convention as
-  // the pivot tree: unknown bucket last, then label asc case-insensitive. This
-  // also decides which sponsors land on which client-side page.
+  // items WITHIN a group), so they default to alphabetical, unknown bucket last.
+  // That test keys on the NAME, not sponsorId, because the card title renders as
+  // `sponsorName || "Unknown sponsor"` — sorting on what the card displays keeps
+  // every "Unknown sponsor" card together at the end. (The pivot tree keys on
+  // the id instead, which splits them: a blank-named sponsor shows the unknown
+  // label but sorts first.) This also decides which sponsors land on which
+  // client-side page.
   groups.sort((a, b) => {
     if (!a.sponsorName !== !b.sponsorName) return a.sponsorName ? -1 : 1;
     return a.sponsorName

--- a/src/components/sponsors/reports/__tests__/ByItemView.test.js
+++ b/src/components/sponsors/reports/__tests__/ByItemView.test.js
@@ -106,7 +106,7 @@ describe("groupLinesBySponsorItem", () => {
     expect(group.items.find((i) => i.itemCode === "B").totalCents).toBe(100);
   });
 
-  it("sorts items qty desc then orders desc, sponsors by totalQty desc", () => {
+  it("sorts items qty desc then orders desc", () => {
     const rows = [
       line({ sponsor: { id: 1, name: "Small" }, item_code: "A", quantity: 1 }),
       line({
@@ -124,9 +124,25 @@ describe("groupLinesBySponsorItem", () => {
       })
     ];
     const groups = groupLinesBySponsorItem(rows);
-    expect(groups.map((g) => g.sponsorName)).toEqual(["Big", "Small"]);
+    const big = groups.find((g) => g.sponsorName === "Big");
     // C: qty 9, orders 2 beats B: qty 9, orders 1
-    expect(groups[0].items.map((i) => i.itemCode)).toEqual(["C", "B"]);
+    expect(big.items.map((i) => i.itemCode)).toEqual(["C", "B"]);
+  });
+
+  it("sorts sponsor groups alphabetically, not by qty, with unknown last", () => {
+    const rows = [
+      line({ sponsor: { id: 1, name: "zeta" }, quantity: 1 }),
+      line({ sponsor: null, quantity: 1 }),
+      // Biggest qty by far — it still sorts on name, not units.
+      line({ sponsor: { id: 2, name: "Nokia" }, quantity: 99 }),
+      line({ sponsor: { id: 3, name: "acme" }, quantity: 1 })
+    ];
+    expect(groupLinesBySponsorItem(rows).map((g) => g.sponsorName)).toEqual([
+      "acme",
+      "Nokia",
+      "zeta",
+      ""
+    ]);
   });
 
   it("passes canceled lines through as contributors with isCanceled", () => {


### PR DESCRIPTION
ref: https://app.clickup.com/t/9014802374/86bbej1g1

## Problem

In the Purchase Details **By Item** report, "By Sponsor" layout, the sponsor accordions came out in what reads as no order at all. They were sorted by total units descending, with the sponsor name only as a tiebreak, so the visible ordering looked arbitrary (the reported screenshot happened to show 8 units / 6 units / 6 units, where the alphabetical looking part was just the tiebreak).

Nothing sorts that level explicitly: the column headers (`ITEM_HEADERS` / `sortItems`) reorder items *within* a sponsor group, and there is no control for the group list itself. So per the request, with no explicit sort the default should be alphabetical.

## Change

`groupLinesBySponsorItem` in `src/components/sponsors/reports/ByItemView.js` now sorts groups by sponsor name instead of by quantity, following the convention already established in `build-pivot-tree.js`: the unknown bucket sorts last, then name ascending, case insensitive.

This also decides which sponsors land on which page, since the view pages over the group list client side.

Untouched on purpose: `finalizeItems` (item order inside a group), `groupLinesByItem` (the All Sponsors layout), and the flat Orders view, whose `-order_date` default is an explicit, intentional sort.

## Tests

The old test `"sorts items qty desc then orders desc, sponsors by totalQty desc"` asserted `["Big", "Small"]`, which is alphabetical too, so it would have kept passing while asserting a contract that no longer exists. It is split:

- the surviving test keeps the item ordering assertion and looks its group up by name
- a new test, `"sorts sponsor groups alphabetically, not by qty, with unknown last"`, uses acme / Nokia / zeta / unknown with Nokia at qty 99, so the old comparator would have put Nokia first. It covers case insensitivity and the null sponsor bucket.

Full suite: 166 suites, 1502 tests passing. `eslint` on both files: 0 errors.
